### PR TITLE
Envolve o elemento graphic em fig

### DIFF
--- a/html_to_xml.py
+++ b/html_to_xml.py
@@ -4,9 +4,7 @@ Converte HTML em XML.
 from lxml import etree
 
 from fixtures import MAIN_HTML_PARAGRAPHS, TRANSLATED_HTML_BY_LANG
-from scielo_classic_website.spsxml.sps_xml_body_pipes import (
-    convert_html_to_xml
-)
+from scielo_classic_website.spsxml.sps_xml_body_pipes import convert_html_to_xml
 
 
 def get_tree(xml_str):

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -597,3 +597,20 @@ class XRefTypePipe(plumber.Pipe):
         raw, xml = data
         _process(xml, "xref", self.parser_node)
         return data
+
+
+class FigPipe(plumber.Pipe):
+    """
+    Envolve o elemento graphic dentro de fig.
+    """
+
+    def parser_node(self, node):
+        parent = node.getparent()
+        p_graphic = parent.getnext().getnext()
+        graphic = p_graphic.getchildren()[0]
+        node.append(graphic)
+
+    def transform(self, data):
+        raw, xml = data
+        _process(xml, "fig[@id]", self.parser_node)
+        return data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -393,6 +393,8 @@ class RenameElementsPipe(plumber.Pipe):
         ("li", "list-item"),
         ("br", "break"),
         ("blockquote", "disp-quote"),
+        ("b", "bold"),
+        ("i", "italic"),
     )
 
     def transform(self, data):

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -604,13 +604,22 @@ class XRefTypePipe(plumber.Pipe):
 class FigPipe(plumber.Pipe):
     """
     Envolve o elemento graphic dentro de fig.
+
+    Resultado esperado:
+
+    <fig id="f1">
+        <graphic xlink:href="f1.jpg"/>
+    </fig>
     """
 
     def parser_node(self, node):
         parent = node.getparent()
-        p_graphic = parent.getnext().getnext()
-        graphic = p_graphic.getchildren()[0]
-        node.append(graphic)
+        for sibling in parent.itersiblings():
+            # Verifica se o elemento irmão é '<p>' e se contém o elemento '<graphic>'.
+            if sibling.tag == "p" and sibling.find("graphic") is not None:
+                graphic = sibling.find("graphic")
+                node.append(graphic)
+                break
 
     def transform(self, data):
         raw, xml = data

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -300,6 +300,8 @@ class TestRenameElementsPipe(TestCase):
                 "</dl>"
                 "<br></br>"
                 "<blockquote>Quote</blockquote>"
+                "<b>Bold</b>"
+                "<i>Italic</i>"
                 "</root>"
             )
         )
@@ -318,6 +320,8 @@ class TestRenameElementsPipe(TestCase):
             "</def-list>"
             "<break/>"
             "<disp-quote>Quote</disp-quote>"
+            "<bold>Bold</bold>"
+            "<italic>Italic</italic>"
             "</root>"
         )
         data = (None, xml)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -613,3 +613,43 @@ class TestFigPipe(TestCase):
         _, transformed_xml = FigPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)
+
+    def test_transform_com_mais_paragrafos_vazios(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<fig id="f1"/>'
+                "</p>"
+                '<p align="center"></p>'
+                '<p align="center"></p>'
+                '<p align="center"></p>'
+                '<p align="center">'
+                '<graphic xlink:href="/fbpe/img/bres/v48/53f01.jpg"/>'
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">'
+            '<fig id="f1">'
+            '<graphic xlink:href="/fbpe/img/bres/v48/53f01.jpg"/>'
+            "</fig>"
+            "</p>"
+            '<p align="center"/>'
+            '<p align="center"/>'
+            '<p align="center"/>'
+            '<p align="center"/>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = FigPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+        self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -7,6 +7,7 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     ANamePipe,
     ASourcePipe,
     EndPipe,
+    FigPipe,
     FontSymbolPipe,
     ImgSrcPipe,
     MainHTMLPipe,
@@ -559,7 +560,7 @@ class TestImgSrcPipe(TestCase):
 
 
 class TestXRefTypePipe(TestCase):
-    def test_ol_pipe(self):
+    def test_transform(self):
         raw = None
         xml = get_tree('<root><body><xref rid="t1">Table 1</xref></body></root>')
         expected = (
@@ -568,5 +569,43 @@ class TestXRefTypePipe(TestCase):
         data = (raw, xml)
 
         _, transformed_xml = XRefTypePipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+        self.assertEqual(expected, result)
+
+
+class TestFigPipe(TestCase):
+    def test_transform(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<fig id="f1"/>'
+                "</p>"
+                '<p align="center"></p>'
+                '<p align="center">'
+                '<graphic xlink:href="/fbpe/img/bres/v48/53f01.jpg"/>'
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">'
+            '<fig id="f1">'
+            '<graphic xlink:href="/fbpe/img/bres/v48/53f01.jpg"/>'
+            "</fig>"
+            "</p>"
+            '<p align="center"/>'
+            '<p align="center"/>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = FigPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?

Envolve o elemento `graphic` em `fig`.

- [x] FigPipe
- [x] TestFigPipe

E a transformação de `b` em `bold` e `i` em `italic`, em `RenameElementsPipe`.

#### Onde a revisão poderia começar?

Lendo os commits.

#### Como este poderia ser testado manualmente?

```
python -m unittest tests/test_sps_xml_body.py
```

#### Algum cenário de contexto que queira dar?

NA

#### Screenshots

NA

#### Quais são tickets relevantes?

#20

#### Referências

NA
