### PR TITLE
Cria pipes para ajudar a resolver a montagem de fig e table-wrap

### DIFF
--- a/html_to_xml.py
+++ b/html_to_xml.py
@@ -42,7 +42,7 @@ def main():
 
     for i, item in enumerate(result):
         print(pretty_print(item))
-        save_file(f"/tmp/output_{i}.xml", item)
+        save_file(f"/tmp/scielo_tmp/output_{i+1}.xml", item)
 
 
 if __name__ == "__main__":

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -625,3 +625,28 @@ class FigPipe(plumber.Pipe):
         raw, xml = data
         _process(xml, "fig[@id]", self.parser_node)
         return data
+
+
+class TableWrapPipe(plumber.Pipe):
+    """
+    Envolve o elemento graphic dentro de table-wrap.
+
+    Resultado esperado:
+
+    <table-wrap id="t1">
+        <graphic xlink:href="t1.jpg"/>
+    </table-wrap>
+    """
+
+    def parser_node(self, node):
+        parent = node.getparent()
+        for sibling in parent.itersiblings():
+            if sibling.tag == "p" and sibling.find("graphic") is not None:
+                graphic = sibling.find("graphic")
+                node.append(graphic)
+                break
+
+    def transform(self, data):
+        raw, xml = data
+        _process(xml, "table-wrap[@id]", self.parser_node)
+        return data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -732,18 +732,22 @@ class RemoveParentPTagOfGraphicPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
+        # Pega o parent do node.
         parent = node.getparent()
 
-        if parent is None:
-            return None
+        # Pega o primeiro filho do node.
+        graphic = node.getchildren()[0]
 
-        if parent.tag == "p":
-            grand_parent = parent.getparent()
-            grand_parent.replace(parent, node)
+        # Adiciona o graphic em parent.
+        index = parent.index(node)
+        parent.insert(index, graphic)
+
+        # Remove o node. <p> com todos os filhos.
+        parent.remove(node)
 
     def transform(self, data):
         raw, xml = data
-        _process(xml, "graphic", self.parser_node)
+        _process(xml, "p[graphic]", self.parser_node)
         return data
 
 

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -671,11 +671,38 @@ class RemoveEmptyPTagPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
-        if node.tag == 'p' and not node.text.strip() and not node.findall('*'):
+        if node.tag == "p" and not node.text.strip() and not node.findall("*"):
             parent = node.getparent()
             parent.remove(node)
 
     def transform(self, data):
         raw, xml = data
         _process(xml, "p", self.parser_node)
+        return data
+
+
+class RemoveParentPTagOfGraphicPipe(plumber.Pipe):
+    """
+    Remove parent de graphic se parent.tag == 'p'.
+
+    Antes:
+
+    <p align="center">
+      <graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>
+    </p>
+
+    Depois:
+
+    <graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>
+    """
+
+    def parser_node(self, node):
+        parent = node.getparent()
+        if parent is not None and parent.tag == "p":
+            grand_parent = parent.getparent()
+            grand_parent.replace(parent, node)
+
+    def transform(self, data):
+        raw, xml = data
+        _process(xml, "graphic", self.parser_node)
         return data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -15,7 +15,7 @@ def convert_html_to_xml(document):
     document.xml_body_and_back.append(convert_html_to_xml_step_2(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_3(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_4(document))
-    document.xml_body_and_back.append(convert_html_to_xml_step_5(document))
+    # document.xml_body_and_back.append(convert_html_to_xml_step_5(document))
 
 
 def convert_html_to_xml_step_1(document):
@@ -101,7 +101,7 @@ def convert_html_to_xml_step_3(document):
         XRefTypePipe(),
         RemoveEmptyPTagPipe(),
         InlineGraphicPipe(),
-        RemoveParentPTagOfGraphicPipe(),
+        # RemoveParentPTagOfGraphicPipe(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)
@@ -127,6 +127,7 @@ def convert_html_to_xml_step_4(document):
     ppl = plumber.Pipeline(
         StartPipe(),
         DivIdToTableWrap(),
+        InsertGraphicInTableWrap(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)
@@ -628,11 +629,17 @@ class FigPipe(plumber.Pipe):
 
     def parser_node(self, node):
         parent = node.getparent()
+
         for sibling in parent.itersiblings():
-            # Verifica se o elemento irmão é '<p>' e se contém o elemento '<graphic>'.
-            if sibling.tag == "p" and sibling.find("graphic") is not None:
+            if sibling.tag != "p":
+                continue
+
+            if sibling.find("graphic") is not None:
                 graphic = sibling.find("graphic")
                 node.append(graphic)
+
+                parent_node = sibling.getparent()
+                parent_node.remove(sibling)
                 break
 
     def transform(self, data):

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -179,6 +179,7 @@ def convert_html_to_xml_step_6(document):
     ppl = plumber.Pipeline(
         StartPipe(),
         InsertGraphicInTableWrapPipe(),
+        InsertTableWrapFootInTableWrapPipe(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)
@@ -883,6 +884,26 @@ class InsertCaptionAndTitleInTableWrapPipe(plumber.Pipe):
 
         # Remove next_node
         parent.getparent().remove(next_node)
+
+    def transform(self, data):
+        raw, xml = data
+        _process(xml, "table-wrap[@id]", self.parser_node)
+        return data
+
+
+class InsertTableWrapFootInTableWrapPipe(plumber.Pipe):
+    """
+    Insere table-wrap-foot em table-wrap.
+    """
+
+    def parser_node(self, node):
+        parent = node.getparent()
+        next_node = parent.getnext()
+
+        table_wrap_foot = ET.Element("table-wrap-foot")
+        table_wrap_foot.append(next_node)
+
+        node.append(table_wrap_foot)
 
     def transform(self, data):
         raw, xml = data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -871,14 +871,13 @@ class InsertCaptionAndTitleInTableWrapPipe(plumber.Pipe):
 
         caption = ET.Element("caption")
 
-        title_element = ET.Element("title")
-        title_element.text = title_text
+        label_element = ET.Element("label")
+        label_element.text = title_text
 
         p_element = ET.Element("p")
         p_element.text = p_text
-        p_element.set("align", "center")
 
-        caption.append(title_element)
+        node.append(label_element)
         caption.append(p_element)
         node.append(caption)
 

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -153,6 +153,8 @@ def convert_html_to_xml_step_5(document):
     """
     ppl = plumber.Pipeline(
         StartPipe(),
+        InsertTitleInTableWrapPipe(),
+        InsertCaptionInTableWrapPipe(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)
@@ -720,10 +722,18 @@ class InsertGraphicInTableWrapPipe(plumber.Pipe):
                 if sibling.find("graphic") is not None:
                     graphic = sibling.find("graphic")
                     node.append(graphic)
+
+                    # Remove o node atual
+                    parent_node = sibling.getparent()
+                    parent_node.remove(sibling)
                     break
                 elif sibling.find("table") is not None:
                     table = sibling.find("table")
                     node.append(table)
+
+                    # Remove o node atual
+                    parent_node = sibling.getparent()
+                    parent_node.remove(sibling)
                     break
 
     def transform(self, data):

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -14,6 +14,7 @@ def convert_html_to_xml(document):
     document.xml_body_and_back.append(convert_html_to_xml_step_1(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_2(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_3(document))
+    document.xml_body_and_back.append(convert_html_to_xml_step_4(document))
 
 
 def convert_html_to_xml_step_1(document):
@@ -670,21 +671,26 @@ class TableWrapPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
+        table_wraper = node.getchildren()[0]
         parent = node.getparent()
-        for sibling in parent.itersiblings():
-            if sibling.tag == "p":
-                if sibling.find("graphic") is not None:
-                    graphic = sibling.find("graphic")
-                    node.append(graphic)
-                    break
-                elif sibling.find("table") is not None:
-                    table = sibling.find("table")
-                    node.append(table)
-                    break
+
+        for sibling in node.itersiblings():
+            if sibling.find("graphic") is not None:
+                graphic = sibling.find("graphic")
+                table_wraper.append(graphic)
+                break
+            elif sibling.find("table") is not None:
+                table = sibling.find("table")
+                table_wraper.append(table)
+                break
+
+        index = parent.index(node)
+        parent.insert(index, table_wraper)
+        parent.remove(node)
 
     def transform(self, data):
         raw, xml = data
-        _process(xml, "table-wrap[@id]", self.parser_node)
+        _process(xml, "p[table-wrap]", self.parser_node)
         return data
 
 

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -97,7 +97,9 @@ def convert_html_to_xml_step_3(document):
     ppl = plumber.Pipeline(
         StartPipe(),
         XRefTypePipe(),
-        TableWrapFigPipe(),
+        RemoveEmptyPTagPipe(),
+        InlineGraphicPipe(),
+        RemoveParentPTagOfGraphicPipe(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)
@@ -124,6 +126,7 @@ def convert_html_to_xml_step_4(document):
     """
     ppl = plumber.Pipeline(
         StartPipe(),
+        TableWrapFigPipe(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -15,7 +15,8 @@ def convert_html_to_xml(document):
     document.xml_body_and_back.append(convert_html_to_xml_step_2(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_3(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_4(document))
-    # document.xml_body_and_back.append(convert_html_to_xml_step_5(document))
+    document.xml_body_and_back.append(convert_html_to_xml_step_5(document))
+    # document.xml_body_and_back.append(convert_html_to_xml_step_6(document))
 
 
 def convert_html_to_xml_step_1(document):
@@ -127,7 +128,7 @@ def convert_html_to_xml_step_4(document):
     ppl = plumber.Pipeline(
         StartPipe(),
         DivIdToTableWrap(),
-        InsertGraphicInTableWrap(),
+        FigPipe(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)
@@ -152,7 +153,31 @@ def convert_html_to_xml_step_5(document):
     """
     ppl = plumber.Pipeline(
         StartPipe(),
-        InsertGraphicInTableWrap(),
+        EndPipe(),
+    )
+    transformed_data = ppl.run(document, rewrap=True)
+    return next(transformed_data)
+
+
+def convert_html_to_xml_step_6(document):
+    """
+    Converte o XML obtido no passo 5,
+
+    Parameters
+    ----------
+    document: Document
+
+    ((address | alternatives | answer | answer-set | array |
+    block-alternatives | boxed-text | chem-struct-wrap | code | explanation |
+    fig | fig-group | graphic | media | preformat | question | question-wrap |
+    question-wrap-group | supplementary-material | table-wrap |
+    table-wrap-group | disp-formula | disp-formula-group | def-list | list |
+    tex-math | mml:math | p | related-article | related-object | disp-quote |
+    speech | statement | verse-group)*, (sec)*, sig-block?)
+    """
+    ppl = plumber.Pipeline(
+        StartPipe(),
+        InsertGraphicInTableWrapPipe(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)
@@ -648,7 +673,7 @@ class FigPipe(plumber.Pipe):
         return data
 
 
-class InsertGraphicInTableWrap(plumber.Pipe):
+class InsertGraphicInTableWrapPipe(plumber.Pipe):
     """
     Envolve o elemento graphic dentro de table-wrap.
 

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -671,9 +671,13 @@ class RemoveEmptyPTagPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
-        if node.tag == "p" and not node.text.strip() and not node.findall("*"):
-            parent = node.getparent()
-            parent.remove(node)
+        if node.findall("*"):
+            return None
+        if node.text.strip():
+            return None
+
+        parent = node.getparent()
+        parent.remove(node)
 
     def transform(self, data):
         raw, xml = data
@@ -688,17 +692,21 @@ class RemoveParentPTagOfGraphicPipe(plumber.Pipe):
     Antes:
 
     <p align="center">
-      <graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>
+      <graphic xlink:href="53t01.jpg"/>
     </p>
 
     Depois:
 
-    <graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>
+    <graphic xlink:href="53t01.jpg"/>
     """
 
     def parser_node(self, node):
         parent = node.getparent()
-        if parent is not None and parent.tag == "p":
+
+        if parent is None:
+            return None
+
+        if parent.tag == "p":
             grand_parent = parent.getparent()
             grand_parent.replace(parent, node)
 

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -16,7 +16,7 @@ def convert_html_to_xml(document):
     document.xml_body_and_back.append(convert_html_to_xml_step_3(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_4(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_5(document))
-    # document.xml_body_and_back.append(convert_html_to_xml_step_6(document))
+    document.xml_body_and_back.append(convert_html_to_xml_step_6(document))
 
 
 def convert_html_to_xml_step_1(document):
@@ -716,24 +716,24 @@ class InsertGraphicInTableWrapPipe(plumber.Pipe):
     def parser_node(self, node):
         parent = node.getparent()
 
-        for sibling in parent.itersiblings():
-            if sibling.tag == "p":
-                if sibling.find("graphic") is not None:
-                    graphic = sibling.find("graphic")
-                    node.append(graphic)
+        sibling = parent.getnext()
 
-                    # Remove o node atual
-                    parent_node = sibling.getparent()
-                    parent_node.remove(sibling)
-                    break
-                elif sibling.find("table") is not None:
-                    table = sibling.find("table")
-                    node.append(table)
+        if sibling.tag == "p":
+            if sibling.find("graphic") is not None:
+                graphic = sibling.find("graphic")
+                node.append(graphic)
 
-                    # Remove o node atual
-                    parent_node = sibling.getparent()
-                    parent_node.remove(sibling)
-                    break
+                # Remove o node atual
+                parent_node = sibling.getparent()
+                parent_node.remove(sibling)
+
+            elif sibling.find("table") is not None:
+                table = sibling.find("table")
+                node.append(table)
+
+                # Remove o node atual
+                parent_node = sibling.getparent()
+                parent_node.remove(sibling)
 
     def transform(self, data):
         raw, xml = data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -696,8 +696,10 @@ class RemoveEmptyPTagPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
+        # Verifica se existe algum filho no node.
         if len(node.getchildren()):
             return None
+        # Verifica se node.text tem conteúdo.
         if node.text.strip():
             return None
 

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -766,24 +766,35 @@ class TableWrapPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
-        table_wraper = node.getchildren()[0]
+        # table_wraper = node.getchildren()[0]
         parent = node.getparent()
 
-        for sibling in node.itersiblings():
-            if sibling.find("graphic") is not None:
-                graphic = sibling.find("graphic")
-                table_wraper.append(graphic)
-                break
-            elif sibling.find("table") is not None:
-                table = sibling.find("table")
-                table_wraper.append(table)
-                break
+        for sibling in parent.itersiblings():
+            if sibling.tag == "p":
+                if sibling.find("graphic") is not None:
+                    graphic = sibling.find("graphic")
+                    node.append(graphic)
+                    break
+                elif sibling.find("table") is not None:
+                    table = sibling.find("table")
+                    node.append(table)
+                    break
 
-        index = parent.index(node)
-        parent.insert(index, table_wraper)
-        parent.remove(node)
+        # for sibling in node.itersiblings():
+        #     if sibling.find("graphic") is not None:
+        #         graphic = sibling.find("graphic")
+        #         table_wraper.append(graphic)
+        #         break
+        #     elif sibling.find("table") is not None:
+        #         table = sibling.find("table")
+        #         table_wraper.append(table)
+        #         break
+
+        # index = parent.index(node)
+        # parent.insert(index, table_wraper)
+        # parent.remove(node)
 
     def transform(self, data):
         raw, xml = data
-        _process(xml, "p[table-wrap]", self.parser_node)
+        _process(xml, "table-wrap[@id]", self.parser_node)
         return data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -636,15 +636,26 @@ class TableWrapPipe(plumber.Pipe):
     <table-wrap id="t1">
         <graphic xlink:href="t1.jpg"/>
     </table-wrap>
+
+    ou
+
+    <table-wrap id="t1">
+        <table/>
+    </table-wrap>
     """
 
     def parser_node(self, node):
         parent = node.getparent()
         for sibling in parent.itersiblings():
-            if sibling.tag == "p" and sibling.find("graphic") is not None:
-                graphic = sibling.find("graphic")
-                node.append(graphic)
-                break
+            if sibling.tag == "p":
+                if sibling.find("graphic") is not None:
+                    graphic = sibling.find("graphic")
+                    node.append(graphic)
+                    break
+                elif sibling.find("table") is not None:
+                    table = sibling.find("table")
+                    node.append(table)
+                    break
 
     def transform(self, data):
         raw, xml = data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -774,18 +774,14 @@ class InlineGraphicPipe(plumber.Pipe):
             _process(node, "graphic", self.graphic_to_inline)
             return
 
+        has_text = False
         for child in node.getchildren():
-            if child.tag != "graphic":
-                continue
-
             if child.tail and child.tail.strip():
-                child.tag = "inline-graphic"
-                continue
+                has_text = True
+                break
 
-            previous = child.getprevious()
-            if previous is not None and previous.tail and previous.tail.strip():
-                child.tag = "inline-graphic"
-                continue
+        if has_text:
+            _process(node, "graphic", self.graphic_to_inline)
 
     def transform(self, data):
         raw, xml = data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -766,7 +766,6 @@ class TableWrapPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
-        # table_wraper = node.getchildren()[0]
         parent = node.getparent()
 
         for sibling in parent.itersiblings():
@@ -779,20 +778,6 @@ class TableWrapPipe(plumber.Pipe):
                     table = sibling.find("table")
                     node.append(table)
                     break
-
-        # for sibling in node.itersiblings():
-        #     if sibling.find("graphic") is not None:
-        #         graphic = sibling.find("graphic")
-        #         table_wraper.append(graphic)
-        #         break
-        #     elif sibling.find("table") is not None:
-        #         table = sibling.find("table")
-        #         table_wraper.append(table)
-        #         break
-
-        # index = parent.index(node)
-        # parent.insert(index, table_wraper)
-        # parent.remove(node)
 
     def transform(self, data):
         raw, xml = data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -267,7 +267,7 @@ class MainHTMLPipe(plumber.Pipe):
             # adiciona ao elemento `back`
             back.append(sec)
 
-        print("back/sec %i" % len(back.findall("sec")))
+        # print("back/sec %i" % len(back.findall("sec")))
 
         return data
 

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -703,8 +703,12 @@ class RemoveEmptyPTagPipe(plumber.Pipe):
         if node.text.strip():
             return None
 
+        tail = node.tail
         parent = node.getparent()
         parent.remove(node)
+
+        # Adiciona o tail no parent.
+        parent.text = tail
 
     def transform(self, data):
         raw, xml = data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -696,7 +696,7 @@ class RemoveEmptyPTagPipe(plumber.Pipe):
     """
 
     def parser_node(self, node):
-        if node.findall("*"):
+        if len(node.getchildren()):
             return None
         if node.text.strip():
             return None

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -714,3 +714,39 @@ class RemoveParentPTagOfGraphicPipe(plumber.Pipe):
         raw, xml = data
         _process(xml, "graphic", self.parser_node)
         return data
+
+
+class InlineGraphicPipe(plumber.Pipe):
+    """
+    Crie um pipe para converter graphic em inline-graphic.
+    Estes graphic são aqueles cujo parent tem
+    text (parent.text and parent.text.strip() e / ou
+    graphic tem tail (graphic.tail and graphic.tail.strip()) e / ou
+    nó anterior tem tail(graphic.getprevious() and graphic.getprevious().tail.strip())
+    """
+
+    def graphic_to_inline(self, node):
+        node.tag = "inline-graphic"
+
+    def parser_node(self, node):
+        if node.text and node.text.strip():
+            _process(node, "graphic", self.graphic_to_inline)
+            return
+
+        for child in node.getchildren():
+            if child.tag != "graphic":
+                continue
+
+            if child.tail and child.tail.strip():
+                child.tag = "inline-graphic"
+                continue
+
+            previous = child.getprevious()
+            if previous is not None and previous.tail and previous.tail.strip():
+                child.tag = "inline-graphic"
+                continue
+
+    def transform(self, data):
+        raw, xml = data
+        _process(xml, "p[graphic]", self.parser_node)
+        return data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -15,6 +15,7 @@ def convert_html_to_xml(document):
     document.xml_body_and_back.append(convert_html_to_xml_step_2(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_3(document))
     document.xml_body_and_back.append(convert_html_to_xml_step_4(document))
+    document.xml_body_and_back.append(convert_html_to_xml_step_5(document))
 
 
 def convert_html_to_xml_step_1(document):
@@ -109,9 +110,32 @@ def convert_html_to_xml_step_3(document):
 
 def convert_html_to_xml_step_4(document):
     """
-    Converte o XML obtido no passo 2,
-    remove o conteúdo de CDATA e converte as tags HTML nas XML correspondentes
-    sem preocupação em manter a hierarquia exigida no XML
+    Converte o XML obtido no passo 3,
+
+    Parameters
+    ----------
+    document: Document
+
+    ((address | alternatives | answer | answer-set | array |
+    block-alternatives | boxed-text | chem-struct-wrap | code | explanation |
+    fig | fig-group | graphic | media | preformat | question | question-wrap |
+    question-wrap-group | supplementary-material | table-wrap |
+    table-wrap-group | disp-formula | disp-formula-group | def-list | list |
+    tex-math | mml:math | p | related-article | related-object | disp-quote |
+    speech | statement | verse-group)*, (sec)*, sig-block?)
+    """
+    ppl = plumber.Pipeline(
+        StartPipe(),
+        DivIdToTableWrap(),
+        EndPipe(),
+    )
+    transformed_data = ppl.run(document, rewrap=True)
+    return next(transformed_data)
+
+
+def convert_html_to_xml_step_5(document):
+    """
+    Converte o XML obtido no passo 4,
 
     Parameters
     ----------
@@ -128,7 +152,6 @@ def convert_html_to_xml_step_4(document):
     ppl = plumber.Pipeline(
         StartPipe(),
         InsertGraphicInTableWrap(),
-        DivIdToTableWrap(),
         EndPipe(),
     )
     transformed_data = ppl.run(document, rewrap=True)

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -634,13 +634,35 @@ class TableWrapPipe(plumber.Pipe):
     """
     Envolve o elemento graphic dentro de table-wrap.
 
+    Antes:
+
+    <p align="center">
+        <table-wrap id="t1"/>
+    </p>
+    <p align="center"> </p>
+    <p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>
+    <p align="center">
+        <graphic xlink:href="t01.jpg"/>
+    </p>
+
     Resultado esperado:
 
     <table-wrap id="t1">
-        <graphic xlink:href="t1.jpg"/>
+        <graphic xlink:href="t01.jpg"/>
     </table-wrap>
 
-    ou
+    Antes:
+
+    <p align="center">
+        <table-wrap id="t1"/>
+    </p>
+    <p align="center"> </p>
+    <p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>
+    <p align="center">
+        <table/>
+    </p>
+
+    Depois:
 
     <table-wrap id="t1">
         <table/>

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -874,11 +874,11 @@ class InsertCaptionAndTitleInTableWrapPipe(plumber.Pipe):
         label_element = ET.Element("label")
         label_element.text = title_text
 
-        p_element = ET.Element("p")
-        p_element.text = p_text
+        title_element = ET.Element("title")
+        title_element.text = p_text
 
         node.append(label_element)
-        caption.append(p_element)
+        caption.append(title_element)
         node.append(caption)
 
         # Remove next_node

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -661,3 +661,21 @@ class TableWrapPipe(plumber.Pipe):
         raw, xml = data
         _process(xml, "table-wrap[@id]", self.parser_node)
         return data
+
+
+class RemoveEmptyPTagPipe(plumber.Pipe):
+    """
+    Remove parágrafo vazio, ou que contenha somente espaços em branco.
+
+    Ex: <p> </p>
+    """
+
+    def parser_node(self, node):
+        if node.tag == 'p' and not node.text.strip() and not node.findall('*'):
+            parent = node.getparent()
+            parent.remove(node)
+
+    def transform(self, data):
+        raw, xml = data
+        _process(xml, "p", self.parser_node)
+        return data

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -669,7 +669,6 @@ class TestTableWrapPipe(TestCase):
                 '<p align="center">'
                 '<table-wrap id="t1"/>'
                 "</p>"
-                '<p align="center"> </p>'
                 '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
                 '<p align="center">'
                 '<graphic xlink:href="t01.jpg"/>'
@@ -681,12 +680,9 @@ class TestTableWrapPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
-            '<p align="center">'
             '<table-wrap id="t1">'
             '<graphic xlink:href="t01.jpg"/>'
             "</table-wrap>"
-            "</p>"
-            '<p align="center"> </p>'
             '<p align="center">'
             "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"
@@ -709,7 +705,6 @@ class TestTableWrapPipe(TestCase):
                 '<p align="center">'
                 '<table-wrap id="t1"/>'
                 "</p>"
-                '<p align="center"> </p>'
                 '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
                 '<p align="center">'
                 "<table><tbody><tr><td>Um</td></tr></tbody></table>"
@@ -721,12 +716,9 @@ class TestTableWrapPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
-            '<p align="center">'
             '<table-wrap id="t1">'
             "<table><tbody><tr><td>Um</td></tr></tbody></table>"
             "</table-wrap>"
-            "</p>"
-            '<p align="center"> </p>'
             '<p align="center">'
             "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -696,3 +696,43 @@ class TestTableWrapPipe(TestCase):
         _, transformed_xml = TableWrapPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)
+
+    def test_transform_with_table(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<table-wrap id="t1"/>'
+                "</p>"
+                '<p align="center"> </p>'
+                '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
+                '<p align="center">'
+                "<table><tbody><tr><td>Um</td></tr></tbody></table>"
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">'
+            '<table-wrap id="t1">'
+            '<table><tbody><tr><td>Um</td></tr></tbody></table>'
+            "</table-wrap>"
+            "</p>"
+            '<p align="center"> </p>'
+            '<p align="center">'
+            "<b>Table 1 Composition and energy provide by the experimental diets</b>"
+            "</p>"
+            '<p align="center"/>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = TableWrapPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+        self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -741,7 +741,8 @@ class TestTableWrapPipe(TestCase):
 
 
 class TestRemoveEmptyPTagPipe(TestCase):
-    def test_transform(self):
+    def test_transform1(self):
+        # Testa a remoção de <p></p> vazios.
         raw = None
         xml = get_tree(
             (
@@ -761,6 +762,89 @@ class TestRemoveEmptyPTagPipe(TestCase):
             "<body>"
             '<p align="center">Lorem ipsum</p>'
             '<p align="center">The quick brown fox jumps over the lazy dog.</p>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveEmptyPTagPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform2(self):
+        # Testa se o graphic se mantem.
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center"><graphic></graphic></p>'
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center"><graphic/></p>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveEmptyPTagPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform3(self):
+        # Testa se um texto formatado dentro de p se mantém, no caso o bold.
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">Lorem ipsum</p>'
+                '<p align="center"> </p>'
+                '<p align="center"> </p>'
+                '<p align="center"> </p>'
+                '<p align="center">The quick <b>brown</b> fox jumps over the lazy dog.</p>'
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">Lorem ipsum</p>'
+            '<p align="center">The quick <b>brown</b> fox jumps over the lazy dog.</p>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveEmptyPTagPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform4(self):
+        # testa um p dentro de outro p.
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center"><p>Inner</p></p>'
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center"><p>Inner</p></p>'
             "</body>"
             "</root>"
         )

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -669,6 +669,7 @@ class TestTableWrapPipe(TestCase):
                 '<p align="center">'
                 '<table-wrap id="t1"/>'
                 "</p>"
+                '<p align="center"> </p>'
                 '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
                 '<p align="center">'
                 '<graphic xlink:href="t01.jpg"/>'
@@ -680,9 +681,12 @@ class TestTableWrapPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
+            '<p align="center">'
             '<table-wrap id="t1">'
             '<graphic xlink:href="t01.jpg"/>'
             "</table-wrap>"
+            "</p>"
+            '<p align="center"> </p>'
             '<p align="center">'
             "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"
@@ -705,6 +709,7 @@ class TestTableWrapPipe(TestCase):
                 '<p align="center">'
                 '<table-wrap id="t1"/>'
                 "</p>"
+                '<p align="center"> </p>'
                 '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
                 '<p align="center">'
                 "<table><tbody><tr><td>Um</td></tr></tbody></table>"
@@ -716,9 +721,12 @@ class TestTableWrapPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
+            '<p align="center">'
             '<table-wrap id="t1">'
             "<table><tbody><tr><td>Um</td></tr></tbody></table>"
             "</table-wrap>"
+            "</p>"
+            '<p align="center"> </p>'
             '<p align="center">'
             "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -12,6 +12,7 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     FontSymbolPipe,
     ImgSrcPipe,
     InlineGraphicPipe,
+    InsertCaptionAndTitleInTableWrapPipe,
     InsertGraphicInTableWrapPipe,
     MainHTMLPipe,
     OlPipe,
@@ -1061,4 +1062,48 @@ class TestInlineGraphicPipe(TestCase):
         _, transformed_xml = InlineGraphicPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
 
+        self.assertEqual(expected, result)
+
+
+class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
+    def test_transform(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<table-wrap id="t1"/>'
+                "</p>"
+                '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
+                '<p align="center">'
+                '<graphic xlink:href="t01.jpg"/>'
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">'
+            '<table-wrap id="t1">'
+            "<caption>"
+            "<title>"
+            "Table 1"
+            "</title>"
+            '<p align="center">Composition and energy provide by the experimental diets</p>'
+            "</caption>"
+            "</table-wrap>"
+            "</p>"
+            '<p align="center">'
+            '<graphic xlink:href="t01.jpg"/>'
+            "</p>"
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = InsertCaptionAndTitleInTableWrapPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -1043,3 +1043,38 @@ class TestInlineGraphicPipe(TestCase):
         result = tree_tostring_decode(transformed_xml)
 
         self.assertEqual(expected, result)
+
+    def test_transform6(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                "<p>"
+                '<graphic id="g1" xlink:href="d1"/> tail 1'
+                '<graphic id="g2" xlink:href="d2"/> tail 2'
+                '<graphic id="g3" xlink:href="d3"/> tail 3'
+                '<graphic id="g4" xlink:href="d4"/> tail 4'
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<p>"
+            '<inline-graphic id="g1" xlink:href="d1"/> tail 1'
+            '<inline-graphic id="g2" xlink:href="d2"/> tail 2'
+            '<inline-graphic id="g3" xlink:href="d3"/> tail 3'
+            '<inline-graphic id="g4" xlink:href="d4"/> tail 4'
+            "</p>"
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = InlineGraphicPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -855,6 +855,32 @@ class TestRemoveEmptyPTagPipe(TestCase):
 
         self.assertEqual(expected, result)
 
+    def test_transform5(self):
+        # testa um p dentro de outro p, onde o segundo é vazio.
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center"><p> </p></p>'
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center"/>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveEmptyPTagPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
 
 class TestRemoveParentPTagOfGraphicPipe(TestCase):
     def test_transform(self):

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -882,6 +882,35 @@ class TestRemoveEmptyPTagPipe(TestCase):
 
         self.assertEqual(expected, result)
 
+    def test_transform6(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                "<div>"
+                '<p> </p> The quick brown fox jumps over the lazy dog.'
+                "</div>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<div>"
+            ' The quick brown fox jumps over the lazy dog.'
+            "</div>"
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveEmptyPTagPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
 
 class TestRemoveParentPTagOfGraphicPipe(TestCase):
     def test_transform(self):

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -1077,11 +1077,13 @@ class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
             "<body>"
             '<p align="center">'
             '<table-wrap id="t1">'
-            "<caption>"
-            "<title>"
+            "<label>"
             "Table 1"
-            "</title>"
-            '<p align="center">Composition and energy provide by the experimental diets</p>'
+            "</label>"
+            "<caption>"
+            "<p>"
+            'Composition and energy provide by the experimental diets'
+            "</p>"
             "</caption>"
             "</table-wrap>"
             "</p>"
@@ -1106,7 +1108,9 @@ class TestInsertTableWrapFootInTableWrapPipe(TestCase):
                 '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
                 "<body>"
                 '<p align="center">'
-                '<table-wrap id="t1"/>'
+                '<table-wrap id="t1">'
+                '<graphic xlink:href="t01.jpg"/>'
+                '</table-wrap>'
                 "</p>"
                 "<p>The quick brown fox jumps over the lazy dog.</p>"
                 "</body>"
@@ -1118,6 +1122,7 @@ class TestInsertTableWrapFootInTableWrapPipe(TestCase):
             "<body>"
             '<p align="center">'
             '<table-wrap id="t1">'
+            '<graphic xlink:href="t01.jpg"/>'
             "<table-wrap-foot>"
             "<p>The quick brown fox jumps over the lazy dog.</p>"
             "</table-wrap-foot>"
@@ -1130,4 +1135,5 @@ class TestInsertTableWrapFootInTableWrapPipe(TestCase):
 
         _, transformed_xml = InsertTableWrapFootInTableWrapPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
+
         self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -1048,7 +1048,7 @@ class TestInlineGraphicPipe(TestCase):
             (
                 '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
                 "<body>"
-                '<p><graphic/>... <graphic/><graphic/><graphic/>....</p>'
+                "<p><graphic/>... <graphic/><graphic/><graphic/>....</p>"
                 "</body>"
                 "</root>"
             )
@@ -1056,7 +1056,7 @@ class TestInlineGraphicPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
-            '<p><inline-graphic/>... <inline-graphic/><inline-graphic/><inline-graphic/>....</p>'
+            "<p><inline-graphic/>... <inline-graphic/><inline-graphic/><inline-graphic/>....</p>"
             "</body>"
             "</root>"
         )

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -14,6 +14,7 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     InlineGraphicPipe,
     InsertCaptionAndTitleInTableWrapPipe,
     InsertGraphicInTableWrapPipe,
+    InsertTableWrapFootInTableWrapPipe,
     MainHTMLPipe,
     OlPipe,
     RemoveCDATAPipe,
@@ -1093,5 +1094,40 @@ class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
         data = (raw, xml)
 
         _, transformed_xml = InsertCaptionAndTitleInTableWrapPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+        self.assertEqual(expected, result)
+
+
+class TestInsertTableWrapFootInTableWrapPipe(TestCase):
+    def test_transform(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<table-wrap id="t1"/>'
+                "</p>"
+                "<p>The quick brown fox jumps over the lazy dog.</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">'
+            '<table-wrap id="t1">'
+            "<table-wrap-foot>"
+            "<p>The quick brown fox jumps over the lazy dog.</p>"
+            "</table-wrap-foot>"
+            "</table-wrap>"
+            "</p>"
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = InsertTableWrapFootInTableWrapPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -672,7 +672,7 @@ class TestTableWrapPipe(TestCase):
                 '<p align="center"> </p>'
                 '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
                 '<p align="center">'
-                '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+                '<graphic xlink:href="t01.jpg"/>'
                 "</p>"
                 "</body>"
                 "</root>"
@@ -683,7 +683,7 @@ class TestTableWrapPipe(TestCase):
             "<body>"
             '<p align="center">'
             '<table-wrap id="t1">'
-            '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+            '<graphic xlink:href="t01.jpg"/>'
             "</table-wrap>"
             "</p>"
             '<p align="center"> </p>'
@@ -889,7 +889,7 @@ class TestRemoveEmptyPTagPipe(TestCase):
                 '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
                 "<body>"
                 "<div>"
-                '<p> </p> The quick brown fox jumps over the lazy dog.'
+                "<p> </p> The quick brown fox jumps over the lazy dog."
                 "</div>"
                 "</body>"
                 "</root>"
@@ -899,7 +899,7 @@ class TestRemoveEmptyPTagPipe(TestCase):
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
             "<div>"
-            ' The quick brown fox jumps over the lazy dog.'
+            " The quick brown fox jumps over the lazy dog."
             "</div>"
             "</body>"
             "</root>"
@@ -913,14 +913,14 @@ class TestRemoveEmptyPTagPipe(TestCase):
 
 
 class TestRemoveParentPTagOfGraphicPipe(TestCase):
-    def test_transform(self):
+    def test_transform1(self):
         raw = None
         xml = get_tree(
             (
                 '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
                 "<body>"
                 '<p align="center">'
-                '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+                '<graphic xlink:href="t01.jpg"/>'
                 "</p>"
                 "</body>"
                 "</root>"
@@ -929,7 +929,44 @@ class TestRemoveParentPTagOfGraphicPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
-            '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+            '<graphic xlink:href="t01.jpg"/>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveParentPTagOfGraphicPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform2(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                "<div>"
+                '<p align="center">'
+                '<graphic xlink:href="t01.jpg"/>'
+                "</p>"
+                '<p align="center"> </p>'
+                "<div/>"
+                "</div>"
+                '<p align="center"> </p>'
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<div>"
+            '<graphic xlink:href="t01.jpg"/>'
+            '<p align="center"> </p>'
+            "<div/>"
+            "</div>"
+            '<p align="center"> </p>'
             "</body>"
             "</root>"
         )

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -1056,12 +1056,13 @@ class TestInlineGraphicPipe(TestCase):
 
 class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
     # https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/tagset/elemento-table-wrap.html
-    def test_transform(self):
+    def test_transform_com_label(self):
         raw = None
         xml = get_tree(
             (
                 '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
                 "<body>"
+                '<p>Mixtures for each of the diets were prepared on an industrial mixer at the Molino La Estampa, Chile, using the proportions for each of the ingredients shown in <xref rid="t1" ref-type="table">Table 1</xref> <xref rid="t2" ref-type="table">Table 2</xref>. Food pellets for each of the animal diets were prepared daily by adding the same amount of water to a fraction of each of the powder mixtures.</p>'
                 '<p align="center">'
                 '<table-wrap id="t1"/>'
                 "</p>"
@@ -1076,6 +1077,7 @@ class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
+            '<p>Mixtures for each of the diets were prepared on an industrial mixer at the Molino La Estampa, Chile, using the proportions for each of the ingredients shown in <xref rid="t1" ref-type="table">Table 1</xref> <xref rid="t2" ref-type="table">Table 2</xref>. Food pellets for each of the animal diets were prepared daily by adding the same amount of water to a fraction of each of the powder mixtures.</p>'
             '<p align="center">'
             '<table-wrap id="t1">'
             "<label>"
@@ -1083,7 +1085,50 @@ class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
             "</label>"
             "<caption>"
             "<title>"
-            'Composition and energy provide by the experimental diets'
+            "Composition and energy provide by the experimental diets"
+            "</title>"
+            "</caption>"
+            "</table-wrap>"
+            "</p>"
+            '<p align="center">'
+            '<graphic xlink:href="t01.jpg"/>'
+            "</p>"
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = InsertCaptionAndTitleInTableWrapPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+        self.assertEqual(expected, result)
+
+    def test_transform_sem_label(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                "<p>Mixtures for each of the diets were prepared on an industrial mixer at the Molino La Estampa, Chile, using the proportions for each of the ingredients shown in. Food pellets for each of the animal diets were prepared daily by adding the same amount of water to a fraction of each of the powder mixtures.</p>"
+                '<p align="center">'
+                '<table-wrap id="t1"/>'
+                "</p>"
+                '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
+                '<p align="center">'
+                '<graphic xlink:href="t01.jpg"/>'
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            "<p>Mixtures for each of the diets were prepared on an industrial mixer at the Molino La Estampa, Chile, using the proportions for each of the ingredients shown in. Food pellets for each of the animal diets were prepared daily by adding the same amount of water to a fraction of each of the powder mixtures.</p>"
+            '<p align="center">'
+            '<table-wrap id="t1">'
+            "<caption>"
+            "<title>"
+            "Composition and energy provide by the experimental diets"
             "</title>"
             "</caption>"
             "</table-wrap>"
@@ -1111,7 +1156,7 @@ class TestInsertTableWrapFootInTableWrapPipe(TestCase):
                 '<p align="center">'
                 '<table-wrap id="t1">'
                 '<graphic xlink:href="t01.jpg"/>'
-                '</table-wrap>'
+                "</table-wrap>"
                 "</p>"
                 "<p>The quick brown fox jumps over the lazy dog.</p>"
                 "</body>"

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -688,7 +688,6 @@ class TestInsertGraphicInTableWrapPipe(TestCase):
             '<p align="center">'
             "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"
-            '<p align="center"/>'
             "</body>"
             "</root>"
         )
@@ -728,7 +727,6 @@ class TestInsertGraphicInTableWrapPipe(TestCase):
             '<p align="center">'
             "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"
-            '<p align="center"/>'
             "</body>"
             "</root>"
         )

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -12,7 +12,7 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     FontSymbolPipe,
     ImgSrcPipe,
     InlineGraphicPipe,
-    InsertGraphicInTableWrap,
+    InsertGraphicInTableWrapPipe,
     MainHTMLPipe,
     OlPipe,
     RemoveCDATAPipe,
@@ -657,7 +657,7 @@ class TestFigPipe(TestCase):
         self.assertEqual(expected, result)
 
 
-class TestInsertGraphicInTableWrap(TestCase):
+class TestInsertGraphicInTableWrapPipe(TestCase):
     def test_transform(self):
         raw = None
         xml = get_tree(
@@ -694,7 +694,7 @@ class TestInsertGraphicInTableWrap(TestCase):
         )
         data = (raw, xml)
 
-        _, transformed_xml = InsertGraphicInTableWrap().transform(data)
+        _, transformed_xml = InsertGraphicInTableWrapPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)
 
@@ -734,7 +734,7 @@ class TestInsertGraphicInTableWrap(TestCase):
         )
         data = (raw, xml)
 
-        _, transformed_xml = InsertGraphicInTableWrap().transform(data)
+        _, transformed_xml = InsertGraphicInTableWrapPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)
 

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -668,8 +668,6 @@ class TestInsertGraphicInTableWrapPipe(TestCase):
                 '<p align="center">'
                 '<table-wrap id="t1"/>'
                 "</p>"
-                '<p align="center"> </p>'
-                '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
                 '<p align="center">'
                 '<graphic xlink:href="t01.jpg"/>'
                 "</p>"
@@ -684,10 +682,6 @@ class TestInsertGraphicInTableWrapPipe(TestCase):
             '<table-wrap id="t1">'
             '<graphic xlink:href="t01.jpg"/>'
             "</table-wrap>"
-            "</p>"
-            '<p align="center"> </p>'
-            '<p align="center">'
-            "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"
             "</body>"
             "</root>"
@@ -707,8 +701,6 @@ class TestInsertGraphicInTableWrapPipe(TestCase):
                 '<p align="center">'
                 '<table-wrap id="t1"/>'
                 "</p>"
-                '<p align="center"> </p>'
-                '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
                 '<p align="center">'
                 "<table><tbody><tr><td>Um</td></tr></tbody></table>"
                 "</p>"
@@ -723,10 +715,6 @@ class TestInsertGraphicInTableWrapPipe(TestCase):
             '<table-wrap id="t1">'
             "<table><tbody><tr><td>Um</td></tr></tbody></table>"
             "</table-wrap>"
-            "</p>"
-            '<p align="center"> </p>'
-            '<p align="center">'
-            "<b>Table 1 Composition and energy provide by the experimental diets</b>"
             "</p>"
             "</body>"
             "</root>"

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -1055,6 +1055,7 @@ class TestInlineGraphicPipe(TestCase):
 
 
 class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
+    # https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/tagset/elemento-table-wrap.html
     def test_transform(self):
         raw = None
         xml = get_tree(
@@ -1081,9 +1082,9 @@ class TestInsertCaptionAndTitleInTableWrapPipe(TestCase):
             "Table 1"
             "</label>"
             "<caption>"
-            "<p>"
+            "<title>"
             'Composition and energy provide by the experimental diets'
-            "</p>"
+            "</title>"
             "</caption>"
             "</table-wrap>"
             "</p>"

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -6,11 +6,13 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     AHrefPipe,
     ANamePipe,
     ASourcePipe,
+    DivIdToTableWrap,
     EndPipe,
     FigPipe,
     FontSymbolPipe,
     ImgSrcPipe,
     InlineGraphicPipe,
+    InsertGraphicInTableWrap,
     MainHTMLPipe,
     OlPipe,
     RemoveCDATAPipe,
@@ -20,8 +22,6 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     RemoveTagsPipe,
     RenameElementsPipe,
     StylePipe,
-    TableWrapFigPipe,
-    TableWrapPipe,
     TagsHPipe,
     TranslatedHTMLPipe,
     UlPipe,
@@ -488,7 +488,7 @@ class TestANamePipe(TestCase):
         self.assertEqual(expected, result)
 
 
-class TestTableWrapFigPipe(TestCase):
+class TestDivIdToTableWrap(TestCase):
     def setUp(self):
         self.input_xml = (
             "<root><body>"
@@ -512,7 +512,7 @@ class TestTableWrapFigPipe(TestCase):
             '<fig id="f3"/>'
             "</body></root>"
         )
-        self.pipe = TableWrapFigPipe()
+        self.pipe = DivIdToTableWrap()
 
     def test_transform(self):
         xml = get_tree(self.input_xml)
@@ -659,7 +659,7 @@ class TestFigPipe(TestCase):
         self.assertEqual(expected, result)
 
 
-class TestTableWrapPipe(TestCase):
+class TestInsertGraphicInTableWrap(TestCase):
     def test_transform(self):
         raw = None
         xml = get_tree(
@@ -696,7 +696,7 @@ class TestTableWrapPipe(TestCase):
         )
         data = (raw, xml)
 
-        _, transformed_xml = TableWrapPipe().transform(data)
+        _, transformed_xml = InsertGraphicInTableWrap().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)
 
@@ -736,7 +736,7 @@ class TestTableWrapPipe(TestCase):
         )
         data = (raw, xml)
 
-        _, transformed_xml = TableWrapPipe().transform(data)
+        _, transformed_xml = InsertGraphicInTableWrap().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)
 

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -608,7 +608,6 @@ class TestFigPipe(TestCase):
             "</fig>"
             "</p>"
             '<p align="center"/>'
-            '<p align="center"/>'
             "</body>"
             "</root>"
         )
@@ -645,7 +644,6 @@ class TestFigPipe(TestCase):
             '<graphic xlink:href="/fbpe/img/bres/v48/53f01.jpg"/>'
             "</fig>"
             "</p>"
-            '<p align="center"/>'
             '<p align="center"/>'
             '<p align="center"/>'
             '<p align="center"/>'

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -10,6 +10,7 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     FigPipe,
     FontSymbolPipe,
     ImgSrcPipe,
+    InlineGraphicPipe,
     MainHTMLPipe,
     OlPipe,
     RemoveCDATAPipe,
@@ -906,6 +907,73 @@ class TestRemoveParentPTagOfGraphicPipe(TestCase):
         data = (raw, xml)
 
         _, transformed_xml = RemoveParentPTagOfGraphicPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+
+class TestInlineGraphicPipe(TestCase):
+    def test_transform1(self):
+        raw = None
+        xml = get_tree(
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p><graphic/></p></body></root>'
+        )
+        expected = '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p><graphic/></p></body></root>'
+        data = (raw, xml)
+
+        _, transformed_xml = InlineGraphicPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform2(self):
+        raw = None
+        xml = get_tree(
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p><graphic id="g1" xlink:href="d1"/>: Rotational</p></body></root>'
+        )
+        expected = '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p><inline-graphic id="g1" xlink:href="d1"/>: Rotational</p></body></root>'
+        data = (raw, xml)
+
+        _, transformed_xml = InlineGraphicPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform3(self):
+        raw = None
+        xml = get_tree(
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p>Models to approximate the bound frequencies as waves in X→M (<graphic id="g1" xlink:href="d1"/></p></body></root>'
+        )
+        expected = '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p>Models to approximate the bound frequencies as waves in X→M (<inline-graphic id="g1" xlink:href="d1"/></p></body></root>'
+        data = (raw, xml)
+
+        _, transformed_xml = InlineGraphicPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform4(self):
+        raw = None
+        xml = get_tree(
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p><italic>y</italic> direction, <graphic id="g3" xlink:href="d3"/></p></body></root>'
+        )
+        expected = '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p><italic>y</italic> direction, <inline-graphic id="g3" xlink:href="d3"/></p></body></root>'
+        data = (raw, xml)
+
+        _, transformed_xml = InlineGraphicPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+    def test_transform5(self):
+        raw = None
+        xml = get_tree(
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p>Models to approximate the bound frequencies as waves in X→M (<graphic id="g1" xlink:href="d1"/>: Rotational, <graphic id="g2" xlink:href="d2"/>: Vibrate in <italic>y</italic> direction, <graphic id="g3" xlink:href="d3"/>: Vibrate in <italic>x</italic> direction, <graphic id="g4" xlink:href="d4"/>: Vibrate mainly in <italic>y</italic> direction including a small portion of vibration in <italic>x</italic> direction, <graphic id="g5" xlink:href="d5"/>: Vibrate mainly in <italic>x</italic> direction including a small portion of vibration in <italic>y</italic> direction).</p></body></root>'
+        )
+        expected = '<root xmlns:xlink="http://www.w3.org/1999/xlink"><body><p>Models to approximate the bound frequencies as waves in X→M (<inline-graphic id="g1" xlink:href="d1"/>: Rotational, <inline-graphic id="g2" xlink:href="d2"/>: Vibrate in <italic>y</italic> direction, <inline-graphic id="g3" xlink:href="d3"/>: Vibrate in <italic>x</italic> direction, <inline-graphic id="g4" xlink:href="d4"/>: Vibrate mainly in <italic>y</italic> direction including a small portion of vibration in <italic>x</italic> direction, <inline-graphic id="g5" xlink:href="d5"/>: Vibrate mainly in <italic>x</italic> direction including a small portion of vibration in <italic>y</italic> direction).</p></body></root>'
+        data = (raw, xml)
+
+        _, transformed_xml = InlineGraphicPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
 
         self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -18,6 +18,7 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     RenameElementsPipe,
     StylePipe,
     TableWrapFigPipe,
+    TableWrapPipe,
     TagsHPipe,
     TranslatedHTMLPipe,
     UlPipe,
@@ -651,5 +652,47 @@ class TestFigPipe(TestCase):
         data = (raw, xml)
 
         _, transformed_xml = FigPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+        self.assertEqual(expected, result)
+
+
+class TestTableWrapPipe(TestCase):
+    def test_transform(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<table-wrap id="t1"/>'
+                "</p>"
+                '<p align="center"> </p>'
+                '<p align="center"><b>Table 1 Composition and energy provide by the experimental diets</b></p>'
+                '<p align="center">'
+                '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">'
+            '<table-wrap id="t1">'
+            '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+            "</table-wrap>"
+            "</p>"
+            '<p align="center"> </p>'
+            '<p align="center">'
+            "<b>Table 1 Composition and energy provide by the experimental diets</b>"
+            "</p>"
+            '<p align="center"/>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = TableWrapPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
         self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -938,13 +938,12 @@ class TestRemoveParentPTagOfGraphicPipe(TestCase):
             (
                 '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
                 "<body>"
-                "<div>"
+                "<p>"
                 '<p align="center">'
                 '<graphic xlink:href="t01.jpg"/>'
                 "</p>"
                 '<p align="center"> </p>'
-                "<div/>"
-                "</div>"
+                "</p>"
                 '<p align="center"> </p>'
                 "</body>"
                 "</root>"
@@ -953,11 +952,10 @@ class TestRemoveParentPTagOfGraphicPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
-            "<div>"
+            "<p>"
             '<graphic xlink:href="t01.jpg"/>'
             '<p align="center"> </p>'
-            "<div/>"
-            "</div>"
+            "</p>"
             '<p align="center"> </p>'
             "</body>"
             "</root>"
@@ -1042,12 +1040,7 @@ class TestInlineGraphicPipe(TestCase):
             (
                 '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
                 "<body>"
-                "<p>"
-                '<graphic id="g1" xlink:href="d1"/> tail 1'
-                '<graphic id="g2" xlink:href="d2"/> tail 2'
-                '<graphic id="g3" xlink:href="d3"/> tail 3'
-                '<graphic id="g4" xlink:href="d4"/> tail 4'
-                "</p>"
+                '<p><graphic/>... <graphic/><graphic/><graphic/>....</p>'
                 "</body>"
                 "</root>"
             )
@@ -1055,12 +1048,7 @@ class TestInlineGraphicPipe(TestCase):
         expected = (
             '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
             "<body>"
-            "<p>"
-            '<inline-graphic id="g1" xlink:href="d1"/> tail 1'
-            '<inline-graphic id="g2" xlink:href="d2"/> tail 2'
-            '<inline-graphic id="g3" xlink:href="d3"/> tail 3'
-            '<inline-graphic id="g4" xlink:href="d4"/> tail 4'
-            "</p>"
+            '<p><inline-graphic/>... <inline-graphic/><inline-graphic/><inline-graphic/>....</p>'
             "</body>"
             "</root>"
         )

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -23,6 +23,7 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     TranslatedHTMLPipe,
     UlPipe,
     XRefTypePipe,
+    RemoveEmptyPTagPipe,
 )
 
 
@@ -735,4 +736,36 @@ class TestTableWrapPipe(TestCase):
 
         _, transformed_xml = TableWrapPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
+        self.assertEqual(expected, result)
+
+
+class TestRemoveEmptyPTagPipe(TestCase):
+    def test_transform(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">Lorem ipsum</p>'
+                '<p align="center"> </p>'
+                '<p align="center"> </p>'
+                '<p align="center"> </p>'
+                '<p align="center">The quick brown fox jumps over the lazy dog.</p>'
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">Lorem ipsum</p>'
+            '<p align="center">The quick brown fox jumps over the lazy dog.</p>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveEmptyPTagPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
         self.assertEqual(expected, result)

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -14,6 +14,8 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     OlPipe,
     RemoveCDATAPipe,
     RemoveCommentPipe,
+    RemoveEmptyPTagPipe,
+    RemoveParentPTagOfGraphicPipe,
     RemoveTagsPipe,
     RenameElementsPipe,
     StylePipe,
@@ -23,7 +25,6 @@ from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     TranslatedHTMLPipe,
     UlPipe,
     XRefTypePipe,
-    RemoveEmptyPTagPipe,
 )
 
 
@@ -721,7 +722,7 @@ class TestTableWrapPipe(TestCase):
             "<body>"
             '<p align="center">'
             '<table-wrap id="t1">'
-            '<table><tbody><tr><td>Um</td></tr></tbody></table>'
+            "<table><tbody><tr><td>Um</td></tr></tbody></table>"
             "</table-wrap>"
             "</p>"
             '<p align="center"> </p>'
@@ -766,6 +767,35 @@ class TestRemoveEmptyPTagPipe(TestCase):
         data = (raw, xml)
 
         _, transformed_xml = RemoveEmptyPTagPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+
+class TestRemoveParentPTagOfGraphicPipe(TestCase):
+    def test_transform(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<graphic xlink:href="/fbpe/img/bres/v48/53t01.jpg"/>'
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = RemoveParentPTagOfGraphicPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
 
         self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?

Cria pipes para ajudar a resolver a montagem de fig e table-wrap

- [x] Cria um pipe para remover elementos `p` vazios (sem *children* e cujo `p.text` corresponde a espaços em branco).
- [x] Cria um pipe para converter `graphic` em `inline-graphic`. Estes `graphic` são aqueles cujo parent tem `text` (`parent.text and parent.text.strip()` e / ou `graphic` tem tail (`graphic.tail and graphic.tail.strip()`) e / ou nó anterior tem tail(`graphic.getprevious() and graphic.getprevious().tail.strip()`)
- [x] Cria um pipe que remova `parent` de `graphic` se `parent.tag == 'p'`

#### Onde a revisão poderia começar?

Lendo os commits.

#### Como este poderia ser testado manualmente?

```
python -m unittest tests/test_sps_xml_body.py
```

#### Algum cenário de contexto que queira dar?

Estes pipes tem que ser executados nesta ordem.
Estes pipes devem fazer parte da conversão de `convert_html_to_xml_step_3` antes de montar fig e table-wrap
Com isso, espera-se que o resultado seja algo similar com:

```xml
<p><fig/></p>
<graphic/>
<p>contém label e caption</p>
```

```xml
<p><table-wrap/></p>
<p>contém label e caption</p>
<graphic/>
```

#### Screenshots

NA

#### Quais são tickets relevantes?

#26

#### Referências

NA