### PR TITLE
[WIP] Transformações em relação ao graphic (JATS) e table em table-wrap

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -50,6 +50,16 @@ Este teste específico, `read_diffchecker_xml_test.py`, requer que você tenha u
 * Google-Chrome aberto
 * Os arquivos `output_*.xml` já devem existir na pasta `/tmp/scielo_tmp/`
 
+E antes você deve rodar
+
+```
+mkdir /tmp/scielo_tmp
+
+python html_to_xml.py
+
+ls -l /tmp/scielo_tmp/
+```
+
 Então rode
 
 ```

--- a/devtools/read_diffchecker_xml_test.py
+++ b/devtools/read_diffchecker_xml_test.py
@@ -2,18 +2,18 @@
 Leia o README.md na mesma pasta.
 """
 
-import pyautogui
 import time
 
+import pyautogui
 
 # pyautogui.position()
 
-pyautogui.hotkey('ctrl', 'shift', 'o')
+pyautogui.hotkey("ctrl", "shift", "o")
 
 time.sleep(2)
 
-pyautogui.write('firefox /tmp/scielo_tmp/output_1.xml', interval=0.02)
-pyautogui.press('enter')
+pyautogui.write("firefox /tmp/scielo_tmp/output_1.xml", interval=0.02)
+pyautogui.press("enter")
 
 time.sleep(1)
 
@@ -22,19 +22,19 @@ pyautogui.click(314, 1289)
 
 # seleciona
 pyautogui.moveTo(321, 1289)
-pyautogui.dragTo(321 + 200, 1289, button='left', duration=0.5)
+pyautogui.dragTo(321 + 200, 1289, button="left", duration=0.5)
 
 # clica expande
 pyautogui.click(314, 1289)
 
 # copia
-pyautogui.hotkey('ctrl', 'c')
+pyautogui.hotkey("ctrl", "c")
 
 # Volta para o terminal
-pyautogui.hotkey('alt', 'tab')
+pyautogui.hotkey("alt", "tab")
 
-pyautogui.write('google-chrome https://www.diffchecker.com/', interval=0.02)
-pyautogui.press('enter')
+pyautogui.write("google-chrome https://www.diffchecker.com/", interval=0.02)
+pyautogui.press("enter")
 
 time.sleep(2)
 
@@ -42,14 +42,14 @@ time.sleep(2)
 pyautogui.click(635, 1458)
 
 # Cola
-pyautogui.hotkey('ctrl', 'v')
+pyautogui.hotkey("ctrl", "v")
 
 # Volta para o terminal
-pyautogui.hotkey('alt', 'tab')
+pyautogui.hotkey("alt", "tab")
 
 # Abre segundo arquivo
-pyautogui.write('firefox /tmp/scielo_tmp/output_2.xml', interval=0.02)
-pyautogui.press('enter')
+pyautogui.write("firefox /tmp/scielo_tmp/output_2.xml", interval=0.02)
+pyautogui.press("enter")
 
 time.sleep(1)
 
@@ -58,19 +58,19 @@ pyautogui.click(314, 1289)
 
 # seleciona
 pyautogui.moveTo(321, 1289)
-pyautogui.dragTo(321 + 200, 1289, button='left', duration=0.5)
+pyautogui.dragTo(321 + 200, 1289, button="left", duration=0.5)
 
 # clica expande
 pyautogui.click(314, 1289)
 
 # copia
-pyautogui.hotkey('ctrl', 'c')
+pyautogui.hotkey("ctrl", "c")
 
 # Volta para o terminal
-pyautogui.keyDown('alt')
-pyautogui.press('tab')
-pyautogui.press('tab')
-pyautogui.keyUp('alt')
+pyautogui.keyDown("alt")
+pyautogui.press("tab")
+pyautogui.press("tab")
+pyautogui.keyUp("alt")
 
 time.sleep(1)
 
@@ -78,7 +78,7 @@ time.sleep(1)
 pyautogui.click(1580, 1458)
 
 # Cola
-pyautogui.hotkey('ctrl', 'v')
+pyautogui.hotkey("ctrl", "v")
 
 # Clica em Find Difference
 pyautogui.click(1222, 1663)
@@ -89,13 +89,13 @@ pyautogui.click(1222, 1663)
 
 for i in range(3, 7):
     # Volta para o terminal
-    pyautogui.keyDown('alt')
-    pyautogui.press('tab')
-    pyautogui.press('tab')
-    pyautogui.keyUp('alt')
+    pyautogui.keyDown("alt")
+    pyautogui.press("tab")
+    pyautogui.press("tab")
+    pyautogui.keyUp("alt")
 
-    pyautogui.write('google-chrome https://www.diffchecker.com/', interval=0.02)
-    pyautogui.press('enter')
+    pyautogui.write("google-chrome https://www.diffchecker.com/", interval=0.02)
+    pyautogui.press("enter")
 
     time.sleep(2)
 
@@ -103,14 +103,14 @@ for i in range(3, 7):
     pyautogui.click(635, 1458)
 
     # Cola
-    pyautogui.hotkey('ctrl', 'v')
+    pyautogui.hotkey("ctrl", "v")
 
     # Volta para o terminal
-    pyautogui.hotkey('alt', 'tab')
+    pyautogui.hotkey("alt", "tab")
 
     # Abre segundo arquivo
-    pyautogui.write(f'firefox /tmp/scielo_tmp/output_{i}.xml', interval=0.02)
-    pyautogui.press('enter')
+    pyautogui.write(f"firefox /tmp/scielo_tmp/output_{i}.xml", interval=0.02)
+    pyautogui.press("enter")
 
     time.sleep(1)
 
@@ -119,19 +119,19 @@ for i in range(3, 7):
 
     # seleciona
     pyautogui.moveTo(321, 1289)
-    pyautogui.dragTo(321 + 200, 1289, button='left', duration=0.5)
+    pyautogui.dragTo(321 + 200, 1289, button="left", duration=0.5)
 
     # clica expande
     pyautogui.click(314, 1289)
 
     # copia
-    pyautogui.hotkey('ctrl', 'c')
+    pyautogui.hotkey("ctrl", "c")
 
     # Volta para o terminal
-    pyautogui.keyDown('alt')
-    pyautogui.press('tab')
-    pyautogui.press('tab')
-    pyautogui.keyUp('alt')
+    pyautogui.keyDown("alt")
+    pyautogui.press("tab")
+    pyautogui.press("tab")
+    pyautogui.keyUp("alt")
 
     time.sleep(1)
 
@@ -139,7 +139,7 @@ for i in range(3, 7):
     pyautogui.click(1580, 1458)
 
     # Cola
-    pyautogui.hotkey('ctrl', 'v')
+    pyautogui.hotkey("ctrl", "v")
 
     # Clica em Find Difference
     pyautogui.click(1222, 1663)

--- a/devtools/read_diffchecker_xml_test.py
+++ b/devtools/read_diffchecker_xml_test.py
@@ -85,9 +85,9 @@ pyautogui.click(1222, 1663)
 
 # ------------------
 
-# for 3 to 6, porque temos 6 arquivos para serem comparados.
+# for 3 to 7, porque temos 7 arquivos para serem comparados.
 
-for i in range(3, 7):
+for i in range(3, 8):
     # Volta para o terminal
     pyautogui.keyDown("alt")
     pyautogui.press("tab")

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -994,15 +994,23 @@ class AlternativesGraphicPipe(plumber.Pipe):
 
         alternatives = ET.Element("alternatives")
 
-        graphic = ET.Element("graphic")
-        graphic.set("{http://www.w3.org/1999/xlink}href", node.attrib["href"])
-        alternatives.append(graphic)
+        graphic1 = ET.Element("graphic")
+        xlink_ref = "{http://www.w3.org/1999/xlink}href"
+        graphic1.set(xlink_ref, node.attrib["href"])
+        alternatives.append(graphic1)
+
+        graphic2 = ET.Element("graphic")
+        xlink_ref = "{http://www.w3.org/1999/xlink}href"
+        graphic2.set(xlink_ref, node.attrib["href"])
+        graphic2.set("specific-use", "scielo-web")
+        alternatives.append(graphic2)
 
         graphic_thumb = ET.Element("graphic")
         graphic_thumb.set(
-            "{http://www.w3.org/1999/xlink}href",
-            _graphic.attrib["{http://www.w3.org/1999/xlink}href"],
+            xlink_ref, _graphic.attrib["{http://www.w3.org/1999/xlink}href"]
         )
+        graphic_thumb.set("specific-use", "scielo-web")
+        graphic_thumb.set("content-type", "scielo-267x140")
         alternatives.append(graphic_thumb)
 
         # Troca o node 'a' por 'alternatives'

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -1208,7 +1208,8 @@ class TestAlternativesGraphicPipe(TestCase):
             '<p align="center">'
             "<alternatives>"
             '<graphic xlink:href="/fbpe/img/bres/v48/53t03.jpg"/>'
-            '<graphic xlink:href="/fbpe/img/bres/v48/53t03thumb.jpg"/>'
+            '<graphic xlink:href="/fbpe/img/bres/v48/53t03.jpg" specific-use="scielo-web"/>'
+            '<graphic xlink:href="/fbpe/img/bres/v48/53t03thumb.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>'
             "</alternatives>"
             "</p>"
             "</body>"

--- a/tests/test_sps_xml_body.py
+++ b/tests/test_sps_xml_body.py
@@ -4,6 +4,7 @@ from lxml import etree
 
 from scielo_classic_website.spsxml.sps_xml_body_pipes import (
     AHrefPipe,
+    AlternativesGraphicPipe,
     ANamePipe,
     ASourcePipe,
     DivIdToTableWrap,
@@ -1180,6 +1181,42 @@ class TestInsertTableWrapFootInTableWrapPipe(TestCase):
         data = (raw, xml)
 
         _, transformed_xml = InsertTableWrapFootInTableWrapPipe().transform(data)
+        result = tree_tostring_decode(transformed_xml)
+
+        self.assertEqual(expected, result)
+
+
+class TestAlternativesGraphicPipe(TestCase):
+    def test_transform(self):
+        raw = None
+        xml = get_tree(
+            (
+                '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+                "<body>"
+                '<p align="center">'
+                '<a href="/fbpe/img/bres/v48/53t03.jpg">'
+                '<graphic xlink:href="/fbpe/img/bres/v48/53t03thumb.jpg"/>'
+                "</a>"
+                "</p>"
+                "</body>"
+                "</root>"
+            )
+        )
+        expected = (
+            '<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            "<body>"
+            '<p align="center">'
+            "<alternatives>"
+            '<graphic xlink:href="/fbpe/img/bres/v48/53t03.jpg"/>'
+            '<graphic xlink:href="/fbpe/img/bres/v48/53t03thumb.jpg"/>'
+            "</alternatives>"
+            "</p>"
+            "</body>"
+            "</root>"
+        )
+        data = (raw, xml)
+
+        _, transformed_xml = AlternativesGraphicPipe().transform(data)
         result = tree_tostring_decode(transformed_xml)
 
         self.assertEqual(expected, result)


### PR DESCRIPTION

#### O que esse PR faz?

- [x] [#21](https://github.com/scieloorg/scielo_migration/issues/21) - Envolve o elemento `graphic` (JATS) e `table` em `table-wrap`
- [x] [#22](https://github.com/scieloorg/scielo_migration/issues/22) - Adiciona em `fig` os elementos `label` e `caption`
- [x] [#23](https://github.com/scieloorg/scielo_migration/issues/23) - Adiciona a `table-wrap` os elementos `label` e `caption`
- [x] [#26](https://github.com/scieloorg/scielo_migration/issues/26) - Cria pipes para ajudar a resolver a montagem de fig e table-wrap
- [x] [#28](https://github.com/scieloorg/scielo_migration/issues/28) - Agrupa as imagens miniatura e padrão em alternatives

#### Onde a revisão poderia começar?

Lendo os commits.

#### Como este poderia ser testado manualmente?

Crie uma nova pasta em `/tmp/`

```
mkdir /tmp/scielo_tmp
```

Rode os testes e o comando

```
python -m unittest tests/test_sps_xml_body.py

python html_to_xml.py  # converte HTML em XML
```

E compare os resultados obtidos.

Estão na pasta `/tmp/scielo_tmp`

Você pode abrir os arquivos (para comparação lado a lado) com o script do [PR 29](https://github.com/scieloorg/scielo_migration/pull/29).

#### Algum cenário de contexto que queira dar?

NA

#### Screenshots

NA

#### Quais são os tickets relevantes?

#21
#22
#23
#26
#28

#### Referências

NA
