### PR TITLE
Corrige a criação de elementos que tenham sub elementos

### DIFF
--- a/scielo_classic_website/spsxml/sps_xml_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_pipes.py
@@ -23,6 +23,7 @@ from scielo_classic_website.spsxml.sps_xml_article_meta import (
     XMLArticleMetaTitleGroupPipe,
     XMLArticleMetaTranslatedTitleGroupPipe,
     XMLNormalizeSpacePipe,
+    create_node_with_fixed_html_text,
 )
 from scielo_classic_website.spsxml.sps_xml_attributes import (
     get_article_type,
@@ -379,25 +380,16 @@ class XMLSubArticlePipe(plumber.Pipe):
             # ARTICLE TITLE
             if raw.translated_titles:
                 titlegroup = ET.Element("title-group")
-                articletitle = ET.Element("article-title")
-                articletitle.set("{http://www.w3.org/XML/1998/namespace}lang", language)
                 title = raw.get_article_title(language)
-                if "&" in title:
-                    articletitle.text = ET.CDATA(title)
-                else:
-                    articletitle.text = title
+                articletitle = create_node_with_fixed_html_text("article-title", title)
+                articletitle.set("{http://www.w3.org/XML/1998/namespace}lang", language)
                 titlegroup.append(articletitle)
                 frontstub.append(titlegroup)
 
             # ABSTRACT
             if raw.translated_abstracts:
-                p = ET.Element("p")
                 text = raw.get_abstract(language)
-                if "&" in text:
-                    p.text = ET.CDATA(text)
-                else:
-                    p.text = text
-                abstract = ET.Element("abstract")
+                abstract = create_node_with_fixed_html_text("p", text)
                 abstract.set("{http://www.w3.org/XML/1998/namespace}lang", language)
                 abstract.append(p)
                 frontstub.append(abstract)
@@ -408,9 +400,7 @@ class XMLSubArticlePipe(plumber.Pipe):
                 kwd_group = ET.Element("kwd-group")
                 kwd_group.set("{http://www.w3.org/XML/1998/namespace}lang", language)
                 for item in keywords_group:
-                    kwd = ET.Element("kwd")
-                    kwd.text = ET.CDATA(item) if "&" in item else item
-                    kwd_group.append(kwd)
+                    kwd_group.append(create_node_with_fixed_html_text("kwd", item))
                 frontstub.append(kwd_group)
             subarticle.append(frontstub)
         return data


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a criação de elementos que tenham sub elementos como article-title, abstract, kwd, ...

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```
In [41]: from scielo_classic_website.spsxml.sps_xml_article_meta import (
    ...: create_node_with_fixed_html_text,
    ...: )

In [44]: n = create_node_with_fixed_html_text("novo", "<B><sup> isso é u teste</b></sup>")

In [45]: etree.tostring(n)
Out[45]: b'<novo><span name="style_sup"> isso &#233; u teste</span></novo>'

In [46]: n = create_node_with_fixed_html_text("novo", "<I><sup> isso é u teste</i></sup>")

In [47]: etree.tostring(n)
Out[47]: b'<novo><span name="style_italic"><span name="style_sup"> isso &#233; u teste</span></span></novo>'


```

#### Algum cenário de contexto que queira dar?
Resolve defeito de apresentação do resumo, título, etc na página do artigo html.


### Screenshots
<img width="429" alt="Captura de Tela 2024-09-23 às 14 34 36" src="https://github.com/user-attachments/assets/7fbfa621-d7d3-4002-b372-7fbd98c67821">

#### Quais são tickets relevantes?
n/a

### Referências
n/a

