### PR TITLE
Scielo migration xml

### DIFF
--- a/scielo_classic_website/spsxml/utils.py
+++ b/scielo_classic_website/spsxml/utils.py
@@ -1,3 +1,6 @@
+from lxml import etree
+
+
 def convert_ahref_to_extlink(xml_etree):
     """
     This methods receives an etree node and replace all "a href" elements to
@@ -40,3 +43,23 @@ def convert_all_html_tags_to_jats(xml_etree):
     xml_etree = convert_html_tags_to_jats(xml_etree)
 
     return xml_etree
+
+
+def handle_bad_text(node, text):
+    try:
+        node.text = text
+    except Exception as e:
+        node.append(etree.Comment(str(e)))
+        node.text = handle_bad_characters(text)
+
+
+def handle_bad_characters(text):
+    chars = []
+    temporary = etree.Element("temporary")
+    for c in text:
+        try:
+            temporary.text = c
+            chars.append(c)
+        except Exception as exc:
+            chars.append('?')
+    return ''.join(chars)


### PR DESCRIPTION
#### O que esse PR faz?
Evita a exceção levantada, mas não é capaz de corrigir os caracteres, causados pela referência:

```
Ste?PIN´SKA, Agnieszka; LIPIN´SKI, Artur; ADAMCZEWSKA, Kinga – «The 2015 parliamentary election in Poland: a political de´ja` vu». In SALGADO, Susana, ed. – Mediated Campaigns andPopulism in Europe. Londres: Palgrave, 2019.
```

 https://scielo.pt/scielo.php?script=sci_arttext&pid=S1645-91992019000200005

```
{'detail': 'null', 'created': '2024-10-28T14:07:25.268328+00:00', 'message': None, 'traceback': '[" File \\"/app/htmlxml/models.py\\", line 714, in _generate_xml_from_html\\n xml_content = document.generate_full_xml(None).decode(\\"utf-8\\")\\n ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/models/document.py\\", line 329, in generate_full_xml\\n return get_xml_rsps(self)\\n ^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_pipes.py\\", line 44, in get_xml_rsps\\n return _process(document)\\n ^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_pipes.py\\", line 91, in _process\\n return next(transformed_data)\\n ^^^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 228, in run\\n for out_data in iterable:\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 140, in __iter__\\n for data in getattr(self, \'_iterable_data\', []):\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 140, in __iter__\\n for data in getattr(self, \'_iterable_data\', []):\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 140, in __iter__\\n for data in getattr(self, \'_iterable_data\', []):\\n", " [Previous line repeated 4 more times]\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 141, in __iter__\\n yield self.transform(data)\\n ^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 109, in decorated\\n return f(*args)\\n ^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_refs.py\\", line 82, in transform\\n raise e\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_refs.py\\", line 69, in transform\\n ref = cit.deploy(xylose_adapters.ReferenceXyloseAdapter(citation))[1]\\n ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_refs.py\\", line 897, in deploy\\n return next(transformed_data)\\n ^^^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 228, in run\\n for out_data in iterable:\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 140, in __iter__\\n for data in getattr(self, \'_iterable_data\', []):\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 140, in __iter__\\n for data in getattr(self, \'_iterable_data\', []):\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 140, in __iter__\\n for data in getattr(self, \'_iterable_data\', []):\\n", " [Previous line repeated 25 more times]\\n", " File \\"/usr/local/lib/python3.11/site-packages/plumber.py\\", line 141, in __iter__\\n yield self.transform(data)\\n ^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_refs.py\\", line 650, in transform\\n person_group = self.build_person_authors(raw.monographic_person_authors)\\n ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_refs.py\\", line 610, in build_person_authors\\n name = self.build_name(author)\\n ^^^^^^^^^^^^^^^^^^^^^^^\\n", " File \\"/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_refs.py\\", line 596, in build_name\\n elem.text = author.get(\\"given_names\\")\\n ^^^^^^^^^\\n", " File \\"src/lxml/etree.pyx\\", line 1049, in lxml.etree._Element.text.__set__\\n", " File \\"src/lxml/apihelpers.pxi\\", line 748, in lxml.etree._setNodeText\\n", " File \\"src/lxml/apihelpers.pxi\\", line 736, in lxml.etree._createTextNode\\n", " File \\"src/lxml/apihelpers.pxi\\", line 1541, in lxml.etree._utf8\\n"]', 'message_type': 'ERROR', 'exception_msg': 'All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters', 'exception_type': "<class 'ValueError'>"}
```


#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

