### PR TITLE
Corrige Document.get_section_title para retornar o título da primeira seção caso não consiga retorná-lo pelo código + idioma

### DIFF
--- a/scielo_classic_website/models/document.py
+++ b/scielo_classic_website/models/document.py
@@ -221,10 +221,10 @@ class Document:
     def get_section_title(self, lang):
         try:
             sections = self.get_sections()
-            section = sections.get(lang) or sections.get("en")
+            section = sections.get(lang) or sections.get("en") or sections.values()[0]
             return section["text"]
         except (TypeError, ValueError, KeyError):
-            return f"{self.issue.get_sections(self.section_code)} {lang} {self.section_code}"
+            return f"Not registered: {self.section_code} {lang}. Registered: {self.issue.get_sections(self.section_code)}"
 
     def get_article_title(self, lang):
         if not hasattr(self, "_article_titles") or not self._article_titles:


### PR DESCRIPTION
#### O que esse PR faz?
Corrige Document.get_section_title para retornar o título da primeira seção caso não consiga retorná-lo pelo código + idioma

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/scms-upload/issues/598

### Referências
n/a
