### PR TITLE
Ajusta identificacao de link interno

### DIFF
--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -406,98 +406,6 @@ class MainHTMLPipe(plumber.Pipe):
         _report(xml, func_name=type(self))
         return data
 
-        # class MainHTMLPipe(plumber.Pipe):
-        #     """
-        #     O texto completo principal é dividido em 3 partes
-        #     - 'before references': antes das referências bibliográficas
-        #     - 'references': referências bibliográficas
-        #     - 'after references': após das referências bibliográficas
-
-        #     Esta etapa espera que exista `raw.main_html_paragraphs` que é
-        #     um dict com chaves: `before references`, `references`, `after references`.
-        #     Os valores de `before references`, `references`, `after references`
-        #     são listas de dict com chaves text, index, reference_index, part.
-
-        #     A partir do raw.main_html_paragraphs, são preenchidos os elementos
-        #     article/body, article/back e article/ref-list
-        #     """
-
-        #     def transform(self, data):
-        #         raw, xml = data
-
-        #         body = xml.find(".//body")
-
-        #         # trata do bloco anterior às referências
-        #         for item in raw.main_html_paragraphs["before references"] or []:
-        #             # item.keys() = (text, index, reference_index, part)
-        #             # cria o elemento `p` com conteúdo de `item['text']`,
-        #             # envolvido por CDATA e adiciona em body
-
-        #             # O CDATA evita que o seu conteúdo seja "parseado" e, assim não
-        #             # acusará erro de má formação do XML. O conteúdo do CDATA será
-        #             # tratado em uma etapa futura
-        #             logging.info("MainHTMLPipe")
-        #             logging.info(item)
-        #             p = ET.Element("p")
-        #             p.text = ET.CDATA(item["text"])
-        #             body.append(p)
-
-        #         # trata do bloco das referências
-        #         references = ET.Element("ref-list")
-        #         for i, item in enumerate(raw.main_html_paragraphs["references"] or []):
-        #             # item.keys() = (text, index, reference_index, part)
-        #             # cria o elemento `ref` com conteúdo de `item['text']`,
-
-        #             logging.info("MainHTMLPipe")
-        #             logging.info(item)
-
-        #             ref = ET.Element("ref")
-        #             try:
-        #                 ref_index = item["reference_index"]
-        #             except KeyError:
-        #                 ref_index = i + 1
-        #             # cria o atributo ref/@id
-        #             ref.set("id", f"B{ref_index}")
-
-        #             # cria o elemento mixed-citation que contém o texto da referência
-        #             # bibliográfica mantendo as pontuação
-        #             mixed_citation = ET.Element("mixed-citation")
-
-        #             # O CDATA evita que o seu conteúdo seja "parseado" e, assim não
-        #             # acusará erro de má formação do XML. O conteúdo do CDATA será
-        #             # tratado em uma etapa futura
-        #             mixed_citation.text = ET.CDATA(item["text"])
-
-        #             # adiciona o elemento que contém o texto da referência
-        #             # bibliográfica ao elemento `ref`
-        #             ref.append(mixed_citation)
-
-        #             # adiciona `ref` ao `ref-list`
-        #             references.append(ref)
-
-        #         # busca o elemento `back`
-        #         back = xml.find(".//back")
-        #         back.append(references)
-        #         for item in raw.main_html_paragraphs["after references"] or []:
-        #             # item.keys() = (text, index, reference_index, part)
-
-        #             # elementos aceitos em `back`
-        #             # (ack | app-group | bio | fn-group | glossary | notes | sec)
-        #             # uso de sec por ser mais genérico
-
-        #             # cria o elemento `sec` para cada item do bloco de 'after references'
-        #             # com conteúdo de `item['text']`
-        #             sec = ET.Element("sec")
-        #             sec.text = ET.CDATA(item["text"])
-
-        #             # adiciona ao elemento `back`
-        #             back.append(sec)
-
-        #         # print("back/sec %i" % len(back.findall("sec")))
-
-        _report(xml, func_name=type(self))  #
-        return data
-
 
 class TranslatedHTMLPipe(plumber.Pipe):
     """
@@ -516,8 +424,11 @@ class TranslatedHTMLPipe(plumber.Pipe):
         raw, xml = data
 
         article = xml.find(".")
+        idx = 0
         for lang, texts in raw.translated_html_by_lang.items():
+            idx += 1
             sub_article = ET.Element("sub-article")
+            sub_article.set("id", f"s0{idx}")
             sub_article.set("article-type", "translation")
             sub_article.set("{http://www.w3.org/XML/1998/namespace}lang", lang)
             article.append(sub_article)
@@ -738,9 +649,9 @@ class AHrefPipe(plumber.Pipe):
         email_from_node_text = None
 
         node.tag = "email"
+        href = (node.get("href") or "").strip()
         node.attrib.clear()
 
-        href = (node.get("href") or "").strip()
         texts = href.replace("mailto:", "")
         for text in texts.split():
             if "@" in text:

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -29,8 +29,7 @@ ELEM_AND_REF_TYPE = {
 }
 
 
-class XMLBodyAnBackConvertException(Exception):
-    ...
+class XMLBodyAnBackConvertException(Exception): ...
 
 
 def delete_tags(root):
@@ -282,6 +281,7 @@ class StartPipe(plumber.Pipe):
     Esta etapa pega o resultado da última conversão feita
     e aplica novas conversões
     """
+
     def precond(data):
         raw = data
         try:
@@ -516,7 +516,9 @@ class RemoveHTMLTagsPipe(plumber.Pipe):
 
 
 class RemoveSpanTagsPipe(plumber.Pipe):
-    TAGS = ["span", ]
+    TAGS = [
+        "span",
+    ]
 
     def transform(self, data):
         raw, xml = data
@@ -811,7 +813,9 @@ class XRefSpecialInternalLinkPipe(plumber.Pipe):
         previous_element_name = None
         label_first_word = None
         children = []
-        for child in xref_parent.xpath("xref[@is_internal_link_to_asset_html_page and @href]"):
+        for child in xref_parent.xpath(
+            "xref[@is_internal_link_to_asset_html_page and @href]"
+        ):
 
             # Table 1
             label = child.text.strip() or " ".join(child.xpath(".//text()")).strip()

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -763,7 +763,7 @@ class AHrefPipe(plumber.Pipe):
         node.tag = "xref"
         node.set("is_internal_link_to_asset_html_page", "true")
 
-    def parser_node(self, node, acron_issue_folder):
+    def parser_node(self, node, journal_acron):
         href = node.get("href") or ""
         if href.count('"') == 2:
             node.set("href", href.replace('"', ""))
@@ -783,7 +783,7 @@ class AHrefPipe(plumber.Pipe):
         if "img/revistas/" in href or ".." in href:
             return self._create_internal_link_to_asset_html_page(node)
 
-        if acron_issue_folder and acron_issue_folder in href:
+        if journal_acron and journal_acron in href:
             return self._create_internal_link_to_asset_html_page(node)
 
         if ":" in href:
@@ -801,10 +801,10 @@ class AHrefPipe(plumber.Pipe):
 
         for node in xml.xpath(".//a[@href]"):
             try:
-                acron_issue_folder = f"/{raw.journal.acronym}/{raw.issue.issue_label}/"
+                journal_acron = f"/{raw.journal.acronym}/"
             except Exception:
-                acron_issue_folder = None
-            self.parser_node(node, acron_issue_folder)
+                journal_acron = None
+            self.parser_node(node, journal_acron)
         _report(xml, func_name=type(self))
         return data
 

--- a/scielo_classic_website/spsxml/sps_xml_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_pipes.py
@@ -145,7 +145,7 @@ class XMLDeleteRepeatedElementWithId(plumber.Pipe):
                 parent = node.getparent()
                 parent.remove(node)
             items.add(_id)
-            
+
     def transform(self, data):
         raw, xml = data
         for subarticle in xml.xpath("sub-article[@article-type='translation']"):

--- a/scielo_classic_website/spsxml/sps_xml_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_pipes.py
@@ -124,33 +124,33 @@ class SetupArticlePipe(plumber.Pipe):
 
 
 class XMLDeleteRepeatedElementWithId(plumber.Pipe):
-    def fix_id_and_rid(self, root):
+    def fix_subarticle_id_and_rid(self, root):
         subarticle_id = root.get("id")
         items = []
         for node in root.xpath(".//*[@id]"):
             _id = node.get("id")
-            item = (node.tag, _id)
-            if item in items:
-                elem = ET.Element("EMPTYTAGTOSTRIP")
-                node.addnext(elem)
-                parent = node.getparent()
-                parent.remove(node)
-            else:
-                items.append(item)
-                if subarticle_id:
-                    new_id = f"{subarticle_id}{_id}"
-                else:
-                    new_id = _id
+            if not _id.startswith(subarticle_id):
+                new_id = f"{subarticle_id}{_id}"
                 node.set("id", new_id)
                 for xref in root.xpath(f".//xref[@rid='{_id}']"):
                     xref.set("rid", new_id)
 
+    def remove_multiplicity(self, root):
+        items = set()
+        for node in root.xpath(".//*[@id]"):
+            _id = node.get("id")
+            if _id in items:
+                elem = ET.Element("EMPTYTAGTOSTRIP")
+                node.addnext(elem)
+                parent = node.getparent()
+                parent.remove(node)
+            items.add(_id)
+            
     def transform(self, data):
         raw, xml = data
-
         for subarticle in xml.xpath("sub-article[@article-type='translation']"):
-            self.fix_id_and_rid(subarticle)
-        self.fix_id_and_rid(xml.find("."))
+            self.fix_subarticle_id_and_rid(subarticle)
+        self.remove_multiplicity(xml.find("."))
         ET.strip_tags(xml, "EMPTYTAGTOSTRIP")
         return data, xml
 
@@ -173,11 +173,7 @@ class XMLDeleteRepeatedTranslations(plumber.Pipe):
             for node in nodes:
                 parent = node.getparent()
                 if parent is not None:
-                    try:
-                        parent.remove(node)
-                    except Exception as e:
-                        logging.exception(e)
-                        to_delete.append((parent, node))
+                    to_delete.append((parent, node))
 
         for parent, node in to_delete:
             if parent is not None:
@@ -357,7 +353,7 @@ class XMLBodyPipe(plumber.Pipe):
         raw, xml = data
 
         converted_html_body = ET.fromstring(raw.xml_body)
-        body = deepcopy(converted_html_body.find(".//body"))
+        body = converted_html_body.find(".//body")
         body.set("specific-use", "quirks-mode")
         xml.append(body)
         return data
@@ -377,7 +373,7 @@ class XMLBackPipe(plumber.Pipe):
         converted_html_body = ET.fromstring(raw.xml_body)
         back = converted_html_body.find(".//back")
         if back is not None:
-            xml.append(deepcopy(back))
+            xml.append(back)
         return data
 
 
@@ -393,8 +389,7 @@ class XMLSubArticlePipe(plumber.Pipe):
         raw, xml = data
 
         converted_html_body = ET.fromstring(raw.xml_body)
-        for subart in converted_html_body.findall(".//sub-article"):
-            subarticle = deepcopy(subart)
+        for subarticle in converted_html_body.findall(".//sub-article"):
             xml.append(subarticle)
 
             language = subarticle.get("{http://www.w3.org/XML/1998/namespace}lang")


### PR DESCRIPTION
#### O que esse PR faz?

Otimizações de performance, correções de bugs e limpeza de código nos módulos de processamento XML.

**Melhorias**
- Reestruturada classe `XMLDeleteRepeatedElementWithId` com separação de responsabilidades
- Otimizada detecção de IDs duplicados usando `set` ao invés de lista
- Melhorada lógica de identificação de links internos

**Correções:**
- Removido `deepcopy()` desnecessário nos pipes XML (XMLBodyPipe, XMLBackPipe, XMLSubArticlePipe)
- Corrigido processamento de atributos `href` para evitar perda de dados
- Removido código comentado obsoleto (98 linhas) da classe `MainHTMLPipe`
- Adicionado sistema de IDs únicos para sub-artigos (`s01`, `s02`, etc.)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando no Upload a migração de pacotes html e observando o arquivos intermediários 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

