### PR TITLE
Corrige levantamento de exceção ao converter XML a partir de HTML na etapa 4

### DIFF
--- a/scielo_classic_website/models/document.py
+++ b/scielo_classic_website/models/document.py
@@ -60,6 +60,7 @@ class Document:
         self._document_records = None
         self.xml_body_and_back = None
         self.xml_body = None
+        self.exceptions = None
 
         self.data = {}
         try:
@@ -302,16 +303,6 @@ class Document:
 
         if main_text or translations:
             sps_xml_body_pipes.convert_html_to_xml(self)
-
-            if not self.xml_body_and_back:
-                raise GenerateBodyAndBackFromHTMLError(
-                    f"XML body and back were not generated"
-                )
-        else:
-            raise GenerateBodyAndBackFromHTMLError(
-                "XML body and back were not generated "
-                "because there is no main text and no translations"
-            )
 
     def generate_full_xml(self, selected_xml_body=None):
         """


### PR DESCRIPTION
#### O que esse PR faz?

Corrige o problema

```
{'traceback': '[\' File "/app/htmlxml/models.py", line 642, in html_to_xml\\n body_and_back = self._generate_xml_body_and_back(\\n ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n\', \' File "/app/htmlxml/models.py", line 747, in _generate_xml_body_and_back\\n document.generate_body_and_back_from_html(languages)\\n\', \' File "/usr/local/lib/python3.11/site-packages/scielo_classic_website/models/document.py", line 304, in generate_body_and_back_from_html\\n sps_xml_body_pipes.convert_html_to_xml(self)\\n\', \' File "/usr/local/lib/python3.11/site-packages/scielo_classic_website/spsxml/sps_xml_body_pipes.py", line 82, in convert_html_to_xml\\n raise XMLBodyAnBackConvertException(\\n\']', 'exception_type': "<class 'scielo_classic_website.spsxml.sps_xml_body_pipes.XMLBodyAnBackConvertException'>", 'exception_message': "convert_html_to_xml (step 4): <class 'AttributeError'> 'NoneType' object has no attribute 'tag'"}
```

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
n/a

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
S0377-94242010000100007

### Referências
n/a
