### PR TITLE
Corrige xref rid 2

### DIFF
--- a/scielo_classic_website/spsxml/sps_xml_article_meta.py
+++ b/scielo_classic_website/spsxml/sps_xml_article_meta.py
@@ -200,7 +200,7 @@ class XMLArticleMetaContribGroupPipe(plumber.Pipe):
     def precond(data):
         raw, xml = data
 
-        if not raw.authors:
+        if not raw.authors and not raw.corporative_authors:
             raise plumber.UnmetPrecondition()
 
     @plumber.precondition(precond)
@@ -254,6 +254,15 @@ class XMLArticleMetaContribGroupPipe(plumber.Pipe):
 
             contrib_group.append(contrib)
 
+        if raw.corporative_authors:
+            collab = ET.Element("collab")
+            collab.text = raw.corporative_authors
+
+            # cria o elemento contrib e seu atributo contrib-type
+            contrib = ET.Element("contrib")
+            contrib.set("contrib-type", "author")
+            contrib.append(collab)
+            contrib_group.append(contrib)
         xml.find("./front/article-meta").append(contrib_group)
 
         return data

--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -936,9 +936,9 @@ class XRefSpecialInternalLinkPipe(plumber.Pipe):
         Returns:
             String com o rid ou None
         """
-        if label_text and label_number:
+        if label_text and label_number and label_number.isdigit():
             try:
-                return ELEM_NAME.get(label_text[0].lower()) + str(label_number)
+                return ELEM_NAME.get(label_text[0].lower())[0] + str(label_number)
             except (IndexError, AttributeError, ValueError):
                 pass
 
@@ -969,7 +969,7 @@ class XRefSpecialInternalLinkPipe(plumber.Pipe):
             return label_text, parts[0]
 
         if len(parts) == 1:
-            return label_text, "01"
+            return label_text, None
 
         if len(parts) == 2 and parts[-1][0].isdigit():
             return parts[0], parts[-1]


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige dois problemas no processamento de XML SPS:
1. Adiciona suporte para autores corporativos que estava ausente no pipeline de metadados do artigo
2. Corrige falhas no processamento de referências internas (xref) no valor atribuído a `rid=`, no lugar de `table-wrap1`, deveria ser `t1`.

#### Onde a revisão poderia começar?
Sugiro iniciar pela revisão em `scielo_classic_website/spsxml/sps_xml_article_meta.py` linha 203, onde foi modificada a precondição para incluir autores corporativos, seguindo para a linha 257 onde o novo bloco de código foi adicionado.

#### Como este poderia ser testado manualmente?
1. **Para autores corporativos:**
   - Processar um documento que contenha apenas `corporative_authors` sem `authors` individuais
   - Verificar se o XML gerado contém o elemento `<collab>` dentro de `<contrib>`
   - Validar que o atributo `contrib-type="author"` está presente

#### Algum cenário de contexto que queira dar?
**Autores corporativos:** Alguns artigos científicos possuem apenas instituições ou organizações como autores (ex: "World Health Organization"), sem autores individuais. O código anterior falhava nesses casos pois a precondição verificava apenas `raw.authors`.

### Screenshots
N/A - Modificações em processamento backend de XML

#### Quais são tickets relevantes?
#103 

### Referências
- Documentação SPS XML para elementos `<collab>` e `<contrib>`
- Padrão JATS para representação de autores corporativos