### PR TITLE
fix(issue_folder): corrige padrões de busca de arquivos em subdiretórios

### DIFF
--- a/scielo_classic_website/models/issue_folder.py
+++ b/scielo_classic_website/models/issue_folder.py
@@ -111,7 +111,7 @@ class IssueFolder:
         pattern = os.path.join(
             self._classic_website_paths.bases_translation_path,
             self._subdir_acron_issue,
-            "*",
+            "*.ht*",
         )
         for item in get_files([pattern], "html"):
             if item.get("error"):
@@ -159,7 +159,7 @@ class IssueFolder:
         pattern = os.path.join(
             self._classic_website_paths.bases_pdf_path,
             self._subdir_acron_issue,
-            "*",
+            "*.*",
         )
         for item in get_files([pattern], "pdf"):
             if item.get("error"):
@@ -200,8 +200,7 @@ class IssueFolder:
         htdocs_path = os.path.dirname(os.path.dirname(htdocs_img_revistas_path))
 
         patterns = [
-            os.path.join(htdocs_path, "**", self._subdir_acron_issue, "*.*"),
-            os.path.join(htdocs_path, "**", self._subdir_acron_issue, "*", "*.*"),
+            os.path.join(htdocs_path, "**", self._subdir_acron_issue, "**", "*.*"),
         ]
 
         for item in get_files(patterns, "asset", True):


### PR DESCRIPTION
#### O que esse PR faz?

Corrige a busca de arquivos em subdiretórios da classe `IssueFolder`. Arquivos em níveis profundos de diretórios (3º nível ou mais) não estavam sendo encontrados, e diretórios estavam sendo processados incorretamente como arquivos.

- bases_translation_files: muda de '*' para '*.ht*' para capturar apenas arquivos HTML (.htm, .html)
- bases_pdf_files: muda de '*' para '*.*' para garantir que apenas arquivos (não diretórios) sejam capturados
- htdocs_img_revistas_files: consolida padrões de busca usando '**' para busca recursiva completa em todos os subdiretórios

O padrão anterior capturava apenas arquivos em níveis específicos (1º e 2º nível). Agora usa 'htdocs/**/acron/issue/**/*.*' garantindo que todos os arquivos em qualquer profundidade de subdiretório sejam encontrados.

#### Onde a revisão poderia começar?

`scielo_classic_website/models/issue_folder.py`, linha 111

#### Como este poderia ser testado manualmente?

```bash
# Criar estrutura de teste
mkdir -p /tmp/test/htdocs/img/revistas/abc/v1n1/sub1/sub2/sub3
echo "test" > /tmp/test/htdocs/img/revistas/abc/v1n1/sub1/sub2/sub3/image.jpg

# Executar no Python
from scielo_classic_website.models.issue_folder import IssueFolder
issue = IssueFolder("abc", "v1n1", paths_config)
assets = list(issue.htdocs_img_revistas_files)
# Deve encontrar image.jpg no 3º nível de subdiretório
```

#### Algum cenário de contexto que queira dar?
Argentina e África do Sul

tentativa de ler "pasta" no lugar de "arquivo"
```
2025-10-21T18:45:18.736733327Z [2025-10-21 18:45:18,734: ERROR/ForkPoolWorker-5491] [Errno 21] Is a directory: '/scielo_www/bases/translation/racir/v110n4/pdf en'
2025-10-21T18:45:18.736821534Z Traceback (most recent call last):
2025-10-21T18:45:18.736835489Z   File "/usr/local/lib/python3.11/site-packages/scielo_classic_website/models/issue_folder.py", line 47, in fixed_glob
2025-10-21T18:45:18.736844668Z     with open(path, "rb") as f:
2025-10-21T18:45:18.736853682Z          ^^^^^^^^^^^^^^^^
2025-10-21T18:45:18.736861979Z IsADirectoryError: [Errno 21] Is a directory: '/scielo_www/bases/translation/racir/v110n4/pdf en'
2025-10-21T18:45:18.738994096Z [2025-10-21 18:45:18,738: ERROR/ForkPoolWorker-5491] [Errno 21] Is a directory: '/scielo_www/bases/translation/racir/v110n4/markup en'
2025-10-21T18:45:18.739026500Z Traceback (most recent call last):
2025-10-21T18:45:18.739034028Z   File 

```

tentativa de carregar pasta no lugar de arquivo
```
Storage can not find an available filename for "classic_website/arg/htdocs/img/revistas/come/v21n2/Comechingoniaewe 21(2) 11 Colasurdo_archivos/Thumbs_s3Q0BDD.db". Please make sure that the corresponding file field allows sufficient "max_length".
```


#### Quais são tickets relevantes?

Relacionado à migração do site clássico para o upload

### Referências

[[Python glob - Recursive patterns](https://docs.python.org/3/library/glob.html#glob.glob)](https://docs.python.org/3/library/glob.html#glob.glob)