### PR TITLE
Correção do processamento de breaks e parágrafos na conversão HTML→XML

### DIFF
--- a/scielo_classic_website/spsxml/sps_xml_body_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_body_pipes.py
@@ -993,7 +993,7 @@ class SizeAttributePipe(plumber.Pipe):
             size = node.get("size")
             if size[0] == "-":
                 continue
-            s = size[0]
+            s = size
             if s[0] == "+":
                 s = s[1:]
             try:


### PR DESCRIPTION
# PR: Correção do processamento de breaks e parágrafos na conversão HTML→XML

## 📋 Descrição

Esta PR corrige o processamento inadequado de tags `<br>` durante a conversão HTML→XML, implementando lógica mais inteligente para identificar quando breaks representam novos parágrafos versus quebras de linha simples.
**Esta correção é necessária para inserir corretamenta as figuras / tabelas representadas no html original como link para arquivos. A conversão html para xml, troca o links por xref + o elemento correspondente com graphic do arquivo.**

## 🎯 Problema

O HTML legado frequentemente usa `<br>` onde deveria usar `<p>`, especialmente:
- **Double breaks** (`<br><br>`) para separar parágrafos
- Elementos `<span>` ou `<font>` seguidos de breaks que deveriam ser parágrafos
- Conteúdo sem estrutura de parágrafos adequada

Porém, nem todo `<br>` representa um novo parágrafo - alguns são quebras de linha legítimas dentro do conteúdo.

## ✨ Solução implementada

### 🔄 Refatoração do pipeline step_2

Dividido em três etapas especializadas para melhor controle do processamento:

- **`step_2_a`**: Conversões básicas HTML→XML (preserva estrutura original)
- **`step_2_b`**: **[FOCO PRINCIPAL]** Correção inteligente de parágrafos:
  - Implementa `FixParagraphsAndBreaksPipe` com lógica específica
  - Adiciona `SizeAttributePipe` para identificar títulos
- **`step_2_c`**: Processamento final de links

### 🆕 Novo pipe: `FixParagraphsAndBreaksPipe`

Implementa detecção inteligente de parágrafos:

1. **Identifica double breaks** (`<br><br>`) como separadores de parágrafo
2. **Converte spans seguidos de double breaks** em `<p>`
3. **Converte fonts seguidos de breaks** em `<p>` ou `<sec>` conforme contexto
4. **Preserva breaks simples** dentro do conteúdo quando apropriado

```python
def fix_paragraphs_and_breaks(self, parent):
    if parent.xpath(".//p"):
        return  # Já tem estrutura de parágrafos
    
    self.mark_double_breaks(parent)  # <br><br> → indicador de parágrafo
    self.replace_span_followed_by_break_by_p(parent)
    self.replace_font_followed_by_break_by_p_or_sec(parent)
```

### 🔧 Melhorias no `ReplaceBrByPPipe`

Refatorado para processar apenas casos com múltiplos breaks:
- Ignora elementos com apenas um `<br>` (quebra simples)
- Divide conteúdo apenas quando há padrão claro de separação

## 📊 Casos de uso cobertos

| Entrada HTML | Saída XML | Justificativa |
|-------------|-----------|---------------|
| `texto<br><br>outro texto` | `<p>texto</p><p>outro texto</p>` | Double break = novo parágrafo |
| `<span>título</span><br><br>conteúdo` | `<p>título</p><p>conteúdo</p>` | Span + double break = parágrafo |
| `linha 1<br>linha 2` | `<p>linha 1<break/>linha 2</p>` | Break simples = quebra de linha |
| `<font size="+2">Seção</font><br><br>` | `<sec><title>Seção</title></sec>` | Font grande + break = seção |

## 🐛 Correções adicionais

- Uso correto de `strip_tags()` ao invés de `parent.remove()` 
- Otimizações de performance em verificações desnecessárias
- Documentação detalhada de todo o pipeline

## 🧪 Validação

- [x] Testado com documentos que usam `<br>` incorretamente no lugar de `<p>`
- [x] Verificado que breaks simples dentro de parágrafos são preservados
- [x] Confirmado que estruturas já corretas (com `<p>`) não são alteradas
- [x] Double breaks são corretamente identificados como separadores

## 💡 Impacto

Esta correção resolve problemas históricos de documentos HTML mal estruturados, garantindo que o XML resultante tenha estrutura semântica correta de parágrafos, mantendo a flexibilidade para quebras de linha legítimas.

## 📝 Arquivos modificados

- `scielo_classic_website/spsxml/sps_xml_body_pipes.py`
