### PR TITLE
fix(spsxml): fix double-tuple nesting in plumber pipes

### DIFF
--- a/scielo_classic_website/spsxml/sps_xml_pipes.py
+++ b/scielo_classic_website/spsxml/sps_xml_pipes.py
@@ -175,7 +175,7 @@ class XMLDeleteRepeatedElementWithId(plumber.Pipe):
             self.fix_subarticle_id_and_rid(subarticle)
         self.remove_multiplicity(xml.find("."))
         ET.strip_tags(xml, "EMPTYTAGTOSTRIP")
-        return data, xml
+        return data
 
 
 class XMLDeleteRepeatedTranslations(plumber.Pipe):
@@ -202,7 +202,7 @@ class XMLDeleteRepeatedTranslations(plumber.Pipe):
             if parent is not None:
                 parent.remove(node)
 
-        return data, xml
+        return data
 
 
 class XMLClosePipe(plumber.Pipe):


### PR DESCRIPTION
#### O que esse PR faz?

Este PR corrige um erro de `AttributeError` que ocorria durante a geração do XML SPS. O problema era causado por um retorno incorreto nos pipes `XMLDeleteRepeatedElementWithId` e `XMLDeleteRepeatedTranslations`.

Ao retornar `data, xml` em vez de apenas `data`, a estrutura de dados era encapsulada em uma tupla adicional, fazendo com que os pipes subsequentes recebessem uma tupla no lugar do objeto de dados (`raw`), impedindo o acesso a atributos como `article_titles`.

#### Onde a revisão poderia começar?

A revisão deve começar no arquivo `scielo_classic_website/spsxml/sps_xml_pipes.py`, especificamente nas classes:

* `XMLDeleteRepeatedElementWithId` (método `transform`)
* `XMLDeleteRepeatedTranslations` (método `transform`)

#### Como este poderia ser testado manualmente?

1. Utilize o ambiente configurado com a biblioteca `scielo_classic_website`.
2. Tente processar o documento com PID `S0034-89102004000200001` (ou qualquer um que utilize o fluxo de geração de XML completo).
3. Execute a chamada `document.generate_full_xml(None)`.
4. Verifique se o processamento completa sem estourar a exceção:
`AttributeError: 'tuple' object has no attribute 'article_titles'`.

#### Algum cenário de contexto que queira dar?

O erro foi identificado no processamento do pacote SPS `1518-8787-rsp-38-02-149`. No framework `plumber`, a saída de um pipe é a entrada do próximo. Quando um pipe retorna `data, xml` estando o `data` já definido como uma tupla `(raw, xml)`, o resultado final enviado ao próximo estágio torna-se `((raw, xml), xml)`. Isso quebra o desempacotamento padrão `raw, xml = data` nos pipes seguintes que tentam acessar metadados do artigo.

### Screenshots

N/A (Erro de processamento em log/backend).

#### Quais são tickets relevantes?

* **Ticket:** get xml
* **PID:** S0034-89102004000200001
* **Data do erro:** Feb. 5, 2026

### Referências

* Documentação da biblioteca `plumber` (Python).
* Stack Trace fornecido no relatório de erro do sistema `htmlxml/models.py`.
