### PR TITLE
fix: sanitiza surrogate pairs em caminhos retornados por get_files

### DIFF
--- a/scielo_classic_website/models/issue_folder.py
+++ b/scielo_classic_website/models/issue_folder.py
@@ -48,18 +48,20 @@ def fixed_glob(patterns, file_type, recursive):
     return paths
 
 
+def _sanitize_surrogates(s: str) -> str:
+    return s.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+
+
 def get_files(patterns, file_type, recursive=False):
-    for path in fixed_glob(patterns, file_type, recursive):
+    for raw_path in fixed_glob(patterns, file_type, recursive):
+        safe_path = _sanitize_surrogates(raw_path)     # para strings/JSON
+        item = {"type": file_type, "path": safe_path}
         try:
-            item = {
-                "type": file_type,
-                "path": path,
-                "modified_date": modified_date(path),
-                "name": os.path.basename(path),
-                "relative_path": _get_classic_website_rel_path(path),
-            }
+            item["modified_date"] = modified_date(raw_path)
+            item["name"] = os.path.basename(safe_path)
             item["key"], item["extension"] = os.path.splitext(item["name"])
-            with open(path, "rb") as f:
+            item["relative_path"] = _get_classic_website_rel_path(safe_path)
+            with open(raw_path, "rb") as f:            # raw_path para I/O
                 item["content"] = f.read()
         except Exception as e:
             logging.exception(e)


### PR DESCRIPTION

#### O que esse PR faz?

Introduz a função auxiliar `_sanitize_surrogates()` em `issue_folder.py` para tratar caminhos de arquivo que contenham sequências surrogate inválidas (geradas, por exemplo, por `os.fsencode` em sistemas de arquivo com nomes corrompidos).

A função converte o caminho para UTF-16 com `surrogatepass` e decodifica de volta com `replace`, produzindo uma string segura para uso em contextos de texto e JSON. O `raw_path` original é preservado exclusivamente para operações de I/O (`open`, `modified_date`), onde o sistema operacional precisa do caminho exato.

#### Onde a revisão poderia começar?

Em `_sanitize_surrogates()` e no refactoring de `get_files()`, observando a separação entre `raw_path` (I/O) e `safe_path` (string/JSON).

#### Como este poderia ser testado manualmente?

Criar um arquivo com nome contendo bytes inválidos (surrogate) em um diretório monitorado pelo SciELO Classic Website e verificar que `get_files()` retorna o item sem lançar exceção, com `path` serializável em JSON.

#### Algum cenário de contexto que queira dar?

O problema se manifesta ao processar coleções com arquivos legados cujos nomes foram gerados em sistemas com encoding inconsistente. Sem o tratamento, a serialização do caminho em JSON lança `UnicodeEncodeError`, interrompendo o pipeline de migração.

### Screenshots

N/A

#### Quais são tickets relevantes?

N/A

### Referências

- [Python docs — `surrogatepass` error handler](https://docs.python.org/3/library/codecs.html#error-handlers)
- [[PEP 383 — Non-decodable bytes in system character interfaces](https://peps.python.org/pep-0383/)](https://peps.python.org/pep-0383/)